### PR TITLE
remove function create in ParquetFile interface

### DIFF
--- a/ParquetFile/LocalFile.go
+++ b/ParquetFile/LocalFile.go
@@ -10,20 +10,18 @@ type LocalFile struct {
 }
 
 func NewLocalFileWriter(name string) (ParquetFile, error) {
-	return (&LocalFile{}).Create(name)
+	file, err := os.Create(name)
+	myFile := &LocalFile{
+		FilePath: name,
+		File:     file,
+	}
+	return myFile, err
 }
 
 func NewLocalFileReader(name string) (ParquetFile, error) {
 	return (&LocalFile{}).Open(name)
 }
 
-func (self *LocalFile) Create(name string) (ParquetFile, error) {
-	file, err := os.Create(name)
-	myFile := new(LocalFile)
-	myFile.File = file
-	return myFile, err
-
-}
 func (self *LocalFile) Open(name string) (ParquetFile, error) {
 	var (
 		err error

--- a/ParquetFile/ParquetFile.go
+++ b/ParquetFile/ParquetFile.go
@@ -10,7 +10,6 @@ type ParquetFile interface {
 	Write(b []byte) (n int, err error)
 	Close()
 	Open(name string) (ParquetFile, error)
-	Create(name string) (ParquetFile, error)
 }
 
 //Convert a file reater to Thrift reader

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ type ParquetFile interface {
 	Write(b []byte) (n int, err error)
 	Close()
 	Open(name string) (ParquetFile, error)
-	Create(name string) (ParquetFile, error)
 }
 ```
 Using this interface, parquet-go can read/write parquet file on different plantforms. Currently local and HDFS interfaces are implemented.(It's not possible for S3, because it doesn't support random access.)


### PR DESCRIPTION
Hi @xitongsys 
I found function `Create` seems useless in interface `ParquetFile`. So I remove it in this PR.
Please help to review it and leave a comment if you find any problem. Thanks!