### PR TITLE
go get github.com/xitongsys/parquet-go/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ parquet-go is a pure-go implementation of reading and writing the parquet format
 ## Install
 Add the parquet-go library to your $GOPATH/src:
 ```sh
-go get github.com/xitongsys/parquet-go
+go get github.com/xitongsys/parquet-go/...
 ```
 Look at a few examples in `example/`. 
 ```sh


### PR DESCRIPTION
`go get github.com/xitongsys/parquet-go` will fetch only 3 files LICENSE, README.md and Makefile making it unusable.

Errors like `no go files in github.com/xitongsys/parquet-go` and
`cannot find package "github.com/xitongsys/parquet-go/ParquetWriter"` will be present.

To hotfix that download all packages (all directories not named main) from repository using command

`go get github.com/xitongsys/parquet-go/...`

----

Updated README