### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ type ParquetFile interface {
 	Create(name string) (ParquetFile, error)
 }
 ```
-Using this interface, parquet-go can read/write parquet file on different plantforms. Currently local and HDFS interfaces are implemented.(It's not possible for S3, because it doesn't support random access.)
+Using this interface, parquet-go can read/write parquet file on different platforms. Currently local and HDFS interfaces are implemented.(It's not possible for S3, because it doesn't support random access.)
 
 ## Writer
 Three Writers are supported: ParquetWriter, JSONWriter, CSVWriter.

--- a/tool/parquet-tools/SchemaTool/SchemaTool.go
+++ b/tool/parquet-tools/SchemaTool/SchemaTool.go
@@ -150,10 +150,10 @@ func (self *Node) OutputJsonSchema() string {
 			scale, precision := self.SE.GetScale(), self.SE.GetPrecision()
 			if *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
 				length := self.SE.GetTypeLength()
-				tagStr = "\"name=%s, type=%s, basetype=%s, scale=%d, precision=%s, length=%d, repetitiontype=%s\""
+				tagStr = "\"name=%s, type=%s, basetype=%s, scale=%d, precision=%d, length=%d, repetitiontype=%s\""
 				res += fmt.Sprintf(tagStr, name, cTStr, pTStr, scale, precision, length, rTStr) + "}"
 			} else {
-				tagStr = "\"name=%s, type=%s, basetype=%s, scale=%d, precision=%s, repetitiontype\""
+				tagStr = "\"name=%s, type=%s, basetype=%s, scale=%d, precision=%d, repetitiontype\""
 				res += fmt.Sprintf(tagStr, name, cTStr, pTStr, scale, precision, rTStr) + "}"
 			}
 


### PR DESCRIPTION
Fixed a formatting error in the parquet-tools schema dump
Updated the struct output of schema dump to include more detail (precision, scale, etc)