### PR TITLE
use io.Writer for ParquetWriters

### DIFF
--- a/ParquetWriter/CSVWriter.go
+++ b/ParquetWriter/CSVWriter.go
@@ -1,9 +1,10 @@
 package ParquetWriter
 
 import (
+	"io"
+
 	"github.com/xitongsys/parquet-go/Layout"
 	"github.com/xitongsys/parquet-go/Marshal"
-	"github.com/xitongsys/parquet-go/ParquetFile"
 	"github.com/xitongsys/parquet-go/ParquetType"
 	"github.com/xitongsys/parquet-go/SchemaHandler"
 	"github.com/xitongsys/parquet-go/parquet"
@@ -14,7 +15,7 @@ type CSVWriter struct {
 }
 
 //Create CSV writer
-func NewCSVWriter(md []string, pfile ParquetFile.ParquetFile, np int64) (*CSVWriter, error) {
+func NewCSVWriter(md []string, pfile io.Writer, np int64) (*CSVWriter, error) {
 	res := new(CSVWriter)
 	res.SchemaHandler = SchemaHandler.NewSchemaHandlerFromMetadata(md)
 	res.PFile = pfile

--- a/ParquetWriter/JSONWriter.go
+++ b/ParquetWriter/JSONWriter.go
@@ -1,9 +1,10 @@
 package ParquetWriter
 
 import (
+	"io"
+
 	"github.com/xitongsys/parquet-go/Layout"
 	"github.com/xitongsys/parquet-go/Marshal"
-	"github.com/xitongsys/parquet-go/ParquetFile"
 	"github.com/xitongsys/parquet-go/SchemaHandler"
 	"github.com/xitongsys/parquet-go/parquet"
 )
@@ -13,7 +14,7 @@ type JSONWriter struct {
 }
 
 //Create JSON writer
-func NewJSONWriter(jsonSchema string, pfile ParquetFile.ParquetFile, np int64) (*JSONWriter, error) {
+func NewJSONWriter(jsonSchema string, pfile io.Writer, np int64) (*JSONWriter, error) {
 	var err error
 	res := new(JSONWriter)
 	res.SchemaHandler, err = SchemaHandler.NewSchemaHandlerFromJSON(jsonSchema)

--- a/ParquetWriter/ParquetWriter.go
+++ b/ParquetWriter/ParquetWriter.go
@@ -2,6 +2,7 @@ package ParquetWriter
 
 import (
 	"encoding/binary"
+	"io"
 	"reflect"
 	"sync"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/xitongsys/parquet-go/Common"
 	"github.com/xitongsys/parquet-go/Layout"
 	"github.com/xitongsys/parquet-go/Marshal"
-	"github.com/xitongsys/parquet-go/ParquetFile"
 	"github.com/xitongsys/parquet-go/SchemaHandler"
 	"github.com/xitongsys/parquet-go/parquet"
 )
@@ -19,7 +19,7 @@ type ParquetWriter struct {
 	SchemaHandler *SchemaHandler.SchemaHandler
 	NP            int64 //parallel number
 	Footer        *parquet.FileMetaData
-	PFile         ParquetFile.ParquetFile
+	PFile         io.Writer
 
 	PageSize        int64
 	RowGroupSize    int64
@@ -41,7 +41,7 @@ type ParquetWriter struct {
 }
 
 //Create a parquet handler
-func NewParquetWriter(pFile ParquetFile.ParquetFile, obj interface{}, np int64) (*ParquetWriter, error) {
+func NewParquetWriter(pFile io.Writer, obj interface{}, np int64) (*ParquetWriter, error) {
 	var err error
 
 	res := new(ParquetWriter)


### PR DESCRIPTION
The only method called is Write, so that no need in full ParquetFile
implementation.