### PR TITLE
In-Memory FileWriter using afero.Fs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - go get github.com/golang/snappy
   - go get git.apache.org/thrift.git/lib/go/thrift
   - go get github.com/colinmarc/hdfs
+  - go get github.com/spf13/afero
 
 script:
   - make test

--- a/ParquetFile/MemFile.go
+++ b/ParquetFile/MemFile.go
@@ -1,0 +1,103 @@
+package ParquetFile
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+// desclare unexported in-memory file-system
+var memFs afero.Fs
+
+// SetInMemFileFs - overrides local in-memory fileSystem
+// NOTE: this is set by NewMemFileWriter is created
+// and memFs is still nil
+func SetInMemFileFs(fs *afero.Fs) {
+	memFs = *fs
+}
+
+// GetMemFileFs - returns the current memory file-system
+// being used by ParquetFile
+func GetMemFileFs() *afero.Fs {
+	return &memFs
+}
+
+// OnCloseFunc function type, handles what to do
+// after converted file is closed in-memory.
+// Close() will pass the filename string and data as io.reader
+type OnCloseFunc func(string, io.Reader)
+
+// MemFile - ParquetFile type for in-memory file operations
+type MemFile struct {
+	FilePath string
+	File     afero.File
+	OnClose  OnCloseFunc
+}
+
+// NewMemFileWriter - intiates and creates an instance of MemFiles
+// NOTE: there is no NewMemFileReader as this particular type was written
+// to handle in-memory converstions and offloading. The results of
+// conversion can then be stored and read via HDFS, LocalFS, etc without
+// the need for loading the file back into memory directly
+func NewMemFileWriter(name string, f OnCloseFunc) (ParquetFile, error) {
+	if memFs == nil {
+		memFs = afero.NewMemMapFs()
+	}
+
+	var m MemFile
+	m.OnClose = f
+	return m.Create(name)
+}
+
+// Create - create in-memory file
+func (fs *MemFile) Create(name string) (ParquetFile, error) {
+	file, err := memFs.Create(name)
+	if err != nil {
+		return fs, err
+	}
+
+	fs.File = file
+	fs.FilePath = name
+	return fs, nil
+}
+
+// Open - open file in-memory
+func (fs *MemFile) Open(name string) (ParquetFile, error) {
+	var (
+		err error
+	)
+	if name == "" {
+		name = fs.FilePath
+	}
+
+	fs.FilePath = name
+	fs.File, err = memFs.Open(name)
+	return fs, err
+}
+
+// Seek - seek function
+func (fs *MemFile) Seek(offset int, pos int) (int64, error) {
+	return fs.File.Seek(int64(offset), pos)
+}
+
+// Read - read file
+func (fs *MemFile) Read(b []byte) (n int, err error) {
+	return fs.File.Read(b)
+}
+
+// Write - write file in-memory
+func (fs *MemFile) Write(b []byte) (n int, err error) {
+	return fs.File.Write(b)
+}
+
+// Close - close file and execute OnCloseFunc
+func (fs *MemFile) Close() {
+	fs.File.Close()
+	if fs.OnClose != nil {
+		f, _ := fs.Open(fs.FilePath)
+		fs.OnClose(filepath.Base(fs.FilePath), f)
+		return
+	}
+	return
+}


### PR DESCRIPTION
So we've been using this library extensively @[Nahuru](http://www.nahuru.com) as it's greatly helped speed up some of our ETL Jobs. 

All our transformations take place in the Cloud on very big Servers with lots of RAM. _Parquet-go_ is pretty resource efficient; even with large Jobs it barely utilises any RAM.

We wanted to see if we could get more speed out of our ETL jobs by doing all our parquet file writing in a RAM based file system.

This pull requests implements the ParquetFile interface using [afero](https://github.com/spf13/afero)

The `NewMemFileWriter` takes a function that takes the contents of the parquet file created in memory as an `io.Reader`, this can in turm create a file, upload to s3 or hdfs.

In our case, our ETL job uploads all transformations to S3 once completed, without writing a single file to disk. This allows us to keep automated disk size low and memory sizes high, (which also simplifies deployment)

This has sped up some of our larger ETL jobs by a factor of 5.

Example:

```go
type Student struct {
	Name   string  `parquet:"name=name, type=UTF8, encoding=PLAIN_DICTIONARY"`
	Age    int32   `parquet:"name=age, type=INT32"`
	Id     int64   `parquet:"name=id, type=INT64"`
	Weight float32 `parquet:"name=weight, type=FLOAT"`
	Sex    bool    `parquet:"name=sex, type=BOOLEAN"`
	Day    int32   `parquet:"name=day, type=DATE"`
}

func main() {
	// create in-memory ParquetFile with Closeer Function
	fw, err := ParquetFile.NewMemFileWriter("flat.parquet.snappy", func(name string, r io.Reader) {
		dat, err := ioutil.ReadAll(r)
		if err != nil {
			log.Printf("error reading data: %v", err)
			os.Exit(1)
		}

		// write file to disk
		if err := ioutil.WriteFile(name, dat, 0644); err != nil {
			log.Printf("error writing result file: %v", err)
		}
	})

	if err != nil {
		log.Println("Can't create local file", err)
		return
	}
	//write
	pw, err := ParquetWriter.NewParquetWriter(fw, new(Student), 4)
	if err != nil {
		log.Println("Can't create parquet writer", err)
		return
	}
	pw.RowGroupSize = 128 * 1024 * 1024 //128M
	pw.CompressionType = parquet.CompressionCodec_SNAPPY
	num := 10
	for i := 0; i < num; i++ {
		stu := Student{
			Name:   "StudentName",
			Age:    int32(20 + i%5),
			Id:     int64(i),
			Weight: float32(50.0 + float32(i)*0.1),
			Sex:    bool(i%2 == 0),
			Day:    int32(time.Now().Unix() / 3600 / 24),
		}
		if err = pw.Write(stu); err != nil {
			log.Println("Write error", err)
		}
	}
	if err = pw.WriteStop(); err != nil {
		log.Println("WriteStop error", err)
		return
	}
	log.Println("Write Finished")
	fw.Close()
	// os.Exit(1)

	///read
	fr, err := ParquetFile.NewLocalFileReader("flat.parquet.snappy")
	if err != nil {
		log.Println("Can't open file")
		return
	}

	pr, err := ParquetReader.NewParquetReader(fr, new(Student), 4)
	if err != nil {
		log.Println("Can't create parquet reader", err)
		return
	}
	num = int(pr.GetNumRows())
	for i := 0; i < num; i++ {
		stus := make([]Student, 1)
		if err = pr.Read(&stus); err != nil {
			log.Println("Read error", err)
		}
		log.Println(stus)
	}
	pr.ReadStop()
	fr.Close()
}
```