### PR TITLE
Capitalises 1st letter in struct field names.

### DIFF
--- a/tool/parquet-tools/SchemaTool/SchemaTool.go
+++ b/tool/parquet-tools/SchemaTool/SchemaTool.go
@@ -232,7 +232,7 @@ func (self *Node) OutputStruct(withName bool, withTags bool) string {
 
 	res := ""
 	if withName {
-		res += name
+		res += strings.Title(name)
 	}
 
 	pT, cT := self.SE.Type, self.SE.ConvertedType


### PR DESCRIPTION
`parquet-tool` outputs the schema in the form of a go struct, but it can't be used as is because fields are unexported. This PR makes them exported.