### PR TITLE
Adds rowcount cmd to parquet-tools, mirroring Java's parquet-tools

### DIFF
--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -28,13 +28,16 @@ func main() {
 		return
 	}
 
-	if *cmd == "schema" {
+	switch *cmd {
+	case "schema":
 		tree := SchemaTool.CreateSchemaTree(pr.SchemaHandler.SchemaElements)
 		fmt.Println("----- Go struct -----")
 		fmt.Printf("%s\n", tree.OutputStruct(*withTags))
 		fmt.Println("----- Json schema -----")
 		fmt.Printf("%s\n", tree.OutputJsonSchema())
-	} else {
+	case "rowcount":
+		fmt.Println(pr.GetNumRows())
+	default:
 		fmt.Println("Unknown command")
 	}
 


### PR DESCRIPTION
```
$ parquet-tools -cmd rowcount -file flat.parquet
2912
```

Note that `rowcount` is the command name used by https://github.com/apache/parquet-mr/tree/master/parquet-tools