### PR TITLE
Implement io.Closer and return errors

### DIFF
--- a/ParquetFile/HdfsFile.go
+++ b/ParquetFile/HdfsFile.go
@@ -83,7 +83,7 @@ func (self *HdfsFile) Write(b []byte) (n int, err error) {
 	return self.FileWriter.Write(b)
 }
 
-func (self *HdfsFile) Close() {
+func (self *HdfsFile) Close() error {
 	if self.FileReader != nil {
 		self.FileReader.Close()
 	}
@@ -93,4 +93,5 @@ func (self *HdfsFile) Close() {
 	if self.Client != nil {
 		self.Client.Close()
 	}
+	return nil
 }

--- a/ParquetFile/LocalFile.go
+++ b/ParquetFile/LocalFile.go
@@ -49,6 +49,6 @@ func (self *LocalFile) Write(b []byte) (n int, err error) {
 	return self.File.Write(b)
 }
 
-func (self *LocalFile) Close() {
-	self.File.Close()
+func (self *LocalFile) Close() error {
+	return self.File.Close()
 }

--- a/ParquetFile/ParquetFile.go
+++ b/ParquetFile/ParquetFile.go
@@ -1,14 +1,16 @@
 package ParquetFile
 
 import (
+	"io"
+
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
 type ParquetFile interface {
-	Seek(offset int64, whence int) (int64, error)
-	Read(b []byte) (n int, err error)
-	Write(b []byte) (n int, err error)
-	Close()
+	io.Seeker
+	io.Reader
+	io.Writer
+	io.Closer
 	Open(name string) (ParquetFile, error)
 	Create(name string) (ParquetFile, error)
 }

--- a/ParquetFile/WriterFile.go
+++ b/ParquetFile/WriterFile.go
@@ -32,5 +32,6 @@ func (self *WriterFile) Write(b []byte) (int, error) {
 	return self.Writer.Write(b)
 }
 
-func (self *WriterFile) Close() {
+func (self *WriterFile) Close() error {
+	return nil
 }

--- a/example/memfs_write.go
+++ b/example/memfs_write.go
@@ -26,7 +26,7 @@ func main() {
 	// create in-memory ParquetFile with Closer Function
 	// NOTE: closer function can be nil, no action will be
 	// run when the writer is closed.
-	fw, err := ParquetFile.NewMemFileWriter("flat.parquet.snappy", func(name string, r io.Reader) {
+	fw, err := ParquetFile.NewMemFileWriter("flat.parquet.snappy", func(name string, r io.Reader) error {
 		dat, err := ioutil.ReadAll(r)
 		if err != nil {
 			log.Printf("error reading data: %v", err)
@@ -37,6 +37,7 @@ func main() {
 		if err := ioutil.WriteFile(name, dat, 0644); err != nil {
 			log.Printf("error writing result file: %v", err)
 		}
+		return nil
 	})
 
 	if err != nil {


### PR DESCRIPTION
This breaks backwards compatibility when using the `ParquetFile.OnCloseFunc` interface.