### PR TITLE
LocalFile.Create() should set FilePath, as in LocalFile.Open()

### DIFF
--- a/ParquetFile/LocalFile.go
+++ b/ParquetFile/LocalFile.go
@@ -20,10 +20,11 @@ func NewLocalFileReader(name string) (ParquetFile, error) {
 func (self *LocalFile) Create(name string) (ParquetFile, error) {
 	file, err := os.Create(name)
 	myFile := new(LocalFile)
+	myFile.FilePath = name
 	myFile.File = file
 	return myFile, err
-
 }
+
 func (self *LocalFile) Open(name string) (ParquetFile, error) {
 	var (
 		err error


### PR DESCRIPTION
The Open() method saves the file path in LocalFile.FilePath, which is useful.
This change makes Create() work the same way.