### PR TITLE
tool/parquet-tools: add the size tool

### DIFF
--- a/tool/parquet-tools/SizeTool/SizeTool.go
+++ b/tool/parquet-tools/SizeTool/SizeTool.go
@@ -1,0 +1,65 @@
+package SizeTool
+
+import (
+	"fmt"
+
+	"github.com/xitongsys/parquet-go/ParquetReader"
+)
+
+func GetParquetFileSize(name string, pr *ParquetReader.ParquetReader, pretty, uncompressedSize bool) string {
+	var size int64
+	if uncompressedSize {
+		size = getUncompressedSize(pr)
+	} else {
+		size = getCompressedSize(pr)
+	}
+
+	if pretty {
+		return fmt.Sprintf("%s: %s", name, getPrettySize(size))
+	}
+	return fmt.Sprintf("%s: %d bytes", name, size)
+}
+
+func getUncompressedSize(pr *ParquetReader.ParquetReader) int64 {
+	var size int64
+	for _, rg := range pr.Footer.RowGroups {
+		size += rg.TotalByteSize
+	}
+	return size
+}
+
+func getCompressedSize(pr *ParquetReader.ParquetReader) int64 {
+	var size int64
+	for _, rg := range pr.Footer.RowGroups {
+		for _, cc := range rg.Columns {
+			size += cc.MetaData.TotalCompressedSize
+		}
+	}
+	return size
+}
+
+func getPrettySize(size int64) string {
+	const (
+		oneKB = 1 << 10
+		oneMB = 1 << 20
+		oneGB = 1 << 30
+		oneTB = 1 << 40
+		onePB = 1 << 50
+	)
+	if size/oneKB < 1 {
+		return fmt.Sprintf("%d bytes", size)
+	}
+	if size/oneMB < 1 {
+		return fmt.Sprintf("%.3f KB", float64(size/oneKB))
+	}
+	if size/oneGB < 1 {
+		return fmt.Sprintf("%.3f MB", float64(size/oneMB))
+	}
+	if size/oneTB < 1 {
+		return fmt.Sprintf("%.3f GB", float64(size/oneGB))
+	}
+	if size/onePB < 1 {
+		return fmt.Sprintf("%.3f TB", float64(size/oneTB))
+	}
+	return fmt.Sprintf("%.3f PB", float64(size/onePB))
+}

--- a/tool/parquet-tools/SizeTool/SizeTool_test.go
+++ b/tool/parquet-tools/SizeTool/SizeTool_test.go
@@ -1,0 +1,96 @@
+package SizeTool
+
+import (
+	"testing"
+
+	"github.com/xitongsys/parquet-go/ParquetReader"
+	"github.com/xitongsys/parquet-go/parquet"
+)
+
+func TestGetParquetFileSize(t *testing.T) {
+	tests := map[string]struct {
+		pr           *ParquetReader.ParquetReader
+		pretty       bool
+		uncompressed bool
+		size         string
+	}{
+		"compresed_size": {
+			pr: &ParquetReader.ParquetReader{
+				Footer: &parquet.FileMetaData{
+					RowGroups: []*parquet.RowGroup{
+						&parquet.RowGroup{
+							Columns: []*parquet.ColumnChunk{
+								&parquet.ColumnChunk{
+									MetaData: &parquet.ColumnMetaData{
+										TotalCompressedSize: 500,
+									},
+								},
+								&parquet.ColumnChunk{
+									MetaData: &parquet.ColumnMetaData{
+										TotalCompressedSize: 501,
+									},
+								},
+							},
+						},
+						&parquet.RowGroup{
+							Columns: []*parquet.ColumnChunk{
+								&parquet.ColumnChunk{
+									MetaData: &parquet.ColumnMetaData{
+										TotalCompressedSize: 233,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pretty:       false,
+			uncompressed: false,
+			size:         "foo: 1234 bytes",
+		},
+		"uncompresed_size": {
+			pr: &ParquetReader.ParquetReader{
+				Footer: &parquet.FileMetaData{
+					RowGroups: []*parquet.RowGroup{
+						&parquet.RowGroup{
+							TotalByteSize: 1001,
+						},
+						&parquet.RowGroup{
+							TotalByteSize: 24,
+						},
+					},
+				},
+			},
+			pretty:       false,
+			uncompressed: true,
+			size:         "foo: 1025 bytes",
+		},
+		"pretty_size_KB": {
+			pr: &ParquetReader.ParquetReader{
+				Footer: &parquet.FileMetaData{
+					RowGroups: []*parquet.RowGroup{
+						&parquet.RowGroup{
+							TotalByteSize: 1001,
+						},
+						&parquet.RowGroup{
+							TotalByteSize: 999,
+						},
+					},
+				},
+			},
+			pretty:       true,
+			uncompressed: true,
+			size:         "foo: 1.953 KB",
+		},
+	}
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			size := GetParquetFileSize("foo", test.pr, test.pretty, test.uncompressed)
+			if size != test.size {
+				t.Errorf("expected: %s, got: %s", test.size, size)
+			}
+		})
+	}
+}

--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -7,12 +7,15 @@ import (
 	"github.com/xitongsys/parquet-go/ParquetFile"
 	"github.com/xitongsys/parquet-go/ParquetReader"
 	"github.com/xitongsys/parquet-go/tool/parquet-tools/SchemaTool"
+	"github.com/xitongsys/parquet-go/tool/parquet-tools/SizeTool"
 )
 
 func main() {
-	cmd := flag.String("cmd", "schema", "command")
+	cmd := flag.String("cmd", "schema", "command to run. Allowed values: schema, rowcount or size")
 	fileName := flag.String("file", "", "file name")
 	withTags := flag.Bool("tag", false, "show struct tags")
+	withPrettySize := flag.Bool("pretty", false, "show pretty size")
+	uncompressedSize := flag.Bool("uncompressed", false, "show uncompressed size")
 
 	flag.Parse()
 
@@ -37,6 +40,8 @@ func main() {
 		fmt.Printf("%s\n", tree.OutputJsonSchema())
 	case "rowcount":
 		fmt.Println(pr.GetNumRows())
+	case "size":
+		fmt.Println(SizeTool.GetParquetFileSize(*fileName, pr, *withPrettySize, *uncompressedSize))
 	default:
 		fmt.Println("Unknown command")
 	}


### PR DESCRIPTION
This pull request adds a size-tool on lines similar to the [size command in parquet-mr project](https://github.com/apache/parquet-mr/blob/dc61e510126aaa1a95a46fe39bf1529f394147e9/parquet-tools/src/main/java/org/apache/parquet/tools/command/SizeCommand.java). The command exposes two new flags viz. `pretty` and `uncompressed`. The first flag prints the size information in human readable format and the latter reports the uncompressed size information about the parquet file. The tool implementation itself is pretty straightforward and uses the 

**PS 1**: This is my first PR in this repo so please forgive my oversight, if any, of the contribution guidelines. I would be happy to learn and adjust. 

**PS 2**: While writing this tool I noticed that the row-group's total-size is being set as [the sum of the compressed-size of the column chunks](https://github.com/xitongsys/parquet-go/blob/master/ParquetWriter/ParquetWriter.go#L280) while the parquet spec requires this field to store [sum of uncompressed size of column chunks](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L736). Please let me know in case I am missing something. If not, I would be glad to fix this in a separate PR. 

