### PR TITLE
Included build tags to exclude compression methods (and dependencies)

### DIFF
--- a/compress/compress.go
+++ b/compress/compress.go
@@ -2,7 +2,7 @@ package compress
 
 import (
 	"fmt"
-	"github.com/tyronegroves/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/parquet"
 )
 
 type Compressor struct {

--- a/compress/compress.go
+++ b/compress/compress.go
@@ -1,80 +1,30 @@
 package compress
 
 import (
-	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io/ioutil"
-
-	"github.com/golang/snappy"
-	"github.com/xitongsys/parquet-go/parquet"
-	"github.com/DataDog/zstd"
+	"github.com/tyronegroves/parquet-go/parquet"
 )
 
-//Uncompress using Gzip
-func UncompressGzip(buf []byte) ([]byte, error) {
-	rbuf := bytes.NewReader(buf)
-	gzipReader, _ := gzip.NewReader(rbuf)
-	res, err := ioutil.ReadAll(gzipReader)
-	return res, err
+type Compressor struct {
+	Compress   func(buf []byte) []byte
+	Uncompress func(buf []byte) ([]byte, error)
 }
 
-//Compress using Gzip
-func CompressGzip(buf []byte) []byte {
-	var res bytes.Buffer
-	gzipWriter := gzip.NewWriter(&res)
-	gzipWriter.Write(buf)
-	gzipWriter.Close()
-	return res.Bytes()
-}
-
-//Uncompress using Snappy
-func UncompressSnappy(buf []byte) ([]byte, error) {
-	return snappy.Decode(nil, buf)
-}
-
-//Compress using Snappy
-func CompressSnappy(buf []byte) []byte {
-	return snappy.Encode(nil, buf)
-}
-
-//Compress using Zstd
-func CompressZstd(buf []byte) []byte {
-	res, _ := zstd.Compress(nil, buf)
-	return res
-}
-
-//Uncompress using Zstd
-func UncompressZstd(buf []byte) ([]byte, error) {
-	return zstd.Decompress(nil, buf)
-}
+var compressors = map[parquet.CompressionCodec]*Compressor{}
 
 func Uncompress(buf []byte, compressMethod parquet.CompressionCodec) ([]byte, error) {
-	switch compressMethod {
-	case parquet.CompressionCodec_GZIP:
-		return UncompressGzip(buf)
-	case parquet.CompressionCodec_SNAPPY:
-		return UncompressSnappy(buf)
-	case parquet.CompressionCodec_ZSTD:
-		return UncompressZstd(buf)
-	case parquet.CompressionCodec_UNCOMPRESSED:
-		return buf, nil
-	default:
-		return nil, fmt.Errorf("Unsupported compress method")
+	c, ok := compressors[compressMethod]
+	if !ok {
+		return nil, fmt.Errorf("unsupported compress method")
 	}
+
+	return c.Uncompress(buf)
 }
 
 func Compress(buf []byte, compressMethod parquet.CompressionCodec) []byte {
-	switch compressMethod {
-	case parquet.CompressionCodec_GZIP:
-		return CompressGzip(buf)
-	case parquet.CompressionCodec_SNAPPY:
-		return CompressSnappy(buf)
-	case parquet.CompressionCodec_ZSTD:
-		return CompressZstd(buf)
-	case parquet.CompressionCodec_UNCOMPRESSED:
-		return buf
-	default:
+	c, ok := compressors[compressMethod]
+	if !ok {
 		return nil
 	}
+	return c.Compress(buf)
 }

--- a/compress/default.go
+++ b/compress/default.go
@@ -1,0 +1,14 @@
+package compress
+
+import "github.com/tyronegroves/parquet-go/parquet"
+
+func init() {
+	compressors[parquet.CompressionCodec_UNCOMPRESSED] = &Compressor{
+		Compress: func(buf []byte) []byte {
+			return buf
+		},
+		Uncompress: func(buf []byte) (bytes []byte, err error) {
+			return buf, nil
+		},
+	}
+}

--- a/compress/default.go
+++ b/compress/default.go
@@ -1,6 +1,6 @@
 package compress
 
-import "github.com/tyronegroves/parquet-go/parquet"
+import "github.com/xitongsys/parquet-go/parquet"
 
 func init() {
 	compressors[parquet.CompressionCodec_UNCOMPRESSED] = &Compressor{

--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -5,7 +5,7 @@ package compress
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/tyronegroves/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/parquet"
 	"io/ioutil"
 )
 

--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -1,0 +1,28 @@
+// +build !no_gzip
+
+package compress
+
+import (
+	"bytes"
+	"compress/gzip"
+	"github.com/tyronegroves/parquet-go/parquet"
+	"io/ioutil"
+)
+
+func init() {
+	compressors[parquet.CompressionCodec_GZIP] = &Compressor{
+		Compress: func(buf []byte) []byte {
+			var res bytes.Buffer
+			gzipWriter := gzip.NewWriter(&res)
+			gzipWriter.Write(buf)
+			gzipWriter.Close()
+			return res.Bytes()
+		},
+		Uncompress: func(buf []byte) (i []byte, err error) {
+			rbuf := bytes.NewReader(buf)
+			gzipReader, _ := gzip.NewReader(rbuf)
+			res, err := ioutil.ReadAll(gzipReader)
+			return res, err
+		},
+	}
+}

--- a/compress/snappy.go
+++ b/compress/snappy.go
@@ -4,7 +4,7 @@ package compress
 
 import (
 	"github.com/golang/snappy"
-	"github.com/tyronegroves/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/parquet"
 )
 
 func init() {

--- a/compress/snappy.go
+++ b/compress/snappy.go
@@ -1,0 +1,19 @@
+// +build !no_snappy
+
+package compress
+
+import (
+	"github.com/golang/snappy"
+	"github.com/tyronegroves/parquet-go/parquet"
+)
+
+func init() {
+	compressors[parquet.CompressionCodec_SNAPPY] = &Compressor{
+		Compress: func(buf []byte) []byte {
+			return snappy.Encode(nil, buf)
+		},
+		Uncompress: func(buf []byte) (bytes []byte, err error) {
+			return snappy.Decode(nil, buf)
+		},
+	}
+}

--- a/compress/zstd.go
+++ b/compress/zstd.go
@@ -4,7 +4,7 @@ package compress
 
 import (
 	"github.com/DataDog/zstd"
-	"github.com/tyronegroves/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/parquet"
 )
 
 func init() {

--- a/compress/zstd.go
+++ b/compress/zstd.go
@@ -1,0 +1,20 @@
+// +build !no_zstd
+
+package compress
+
+import (
+	"github.com/DataDog/zstd"
+	"github.com/tyronegroves/parquet-go/parquet"
+)
+
+func init() {
+	compressors[parquet.CompressionCodec_ZSTD] = &Compressor{
+		Compress: func(buf []byte) []byte {
+			res, _ := zstd.Compress(nil, buf)
+			return res
+		},
+		Uncompress: func(buf []byte) (bytes []byte, err error) {
+			return zstd.Decompress(nil, buf)
+		},
+	}
+}


### PR DESCRIPTION
This will let builds exclude the zstd dependency to allow for pure Go builds with no CGO needed. 