### PR TITLE
Gzip compress performance optimization

### DIFF
--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -26,6 +26,7 @@ func init() {
 			gzipWriter.Reset(res)
 			gzipWriter.Write(buf)
 			gzipWriter.Close()
+			gzipWriter.Reset(nil)
 			gzipWriterPool.Put(gzipWriter)
 			return res.Bytes()
 		},

--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -11,7 +11,6 @@ import (
 )
 
 var gzipWriterPool sync.Pool
-var buffersPool sync.Pool
 
 func init() {
 	gzipWriterPool = sync.Pool{
@@ -20,21 +19,13 @@ func init() {
 		},
 	}
 
-	buffersPool = sync.Pool{
-		New: func() interface{} {
-			return new(bytes.Buffer)
-		},
-	}
-
 	compressors[parquet.CompressionCodec_GZIP] = &Compressor{
 		Compress: func(buf []byte) []byte {
-			res := buffersPool.Get().(*bytes.Buffer)
-			res.Reset()
+			res := new(bytes.Buffer)
 			gzipWriter := gzipWriterPool.Get().(*gzip.Writer)
 			gzipWriter.Reset(res)
 			gzipWriter.Write(buf)
 			gzipWriter.Close()
-			buffersPool.Put(res)
 			gzipWriterPool.Put(gzipWriter)
 			return res.Bytes()
 		},

--- a/compress/gzip_test.go
+++ b/compress/gzip_test.go
@@ -1,0 +1,1 @@
+package compress

--- a/compress/gzip_test.go
+++ b/compress/gzip_test.go
@@ -1,1 +1,30 @@
 package compress
+
+import (
+	"bytes"
+	"github.com/xitongsys/parquet-go/parquet"
+	"testing"
+)
+
+func TestGzipCompression(t *testing.T) {
+	gzipCompressor := compressors[parquet.CompressionCodec_GZIP]
+	input := []byte("test data")
+	compressed := gzipCompressor.Compress(input)
+	output, err := gzipCompressor.Uncompress(compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(input, output) {
+		t.Fatalf("expected output %s but was %s", string(input), string(output))
+	}
+}
+
+func BenchmarkGzipCompression(b *testing.B) {
+	gzipCompressor := compressors[parquet.CompressionCodec_GZIP]
+	input := []byte("test data")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		gzipCompressor.Compress(input)
+	}
+}


### PR DESCRIPTION
use sync.Pool for gzip Compression in order to improve performance and memory usage by reusing both gzip.Writer and bytes.Buffer objects.  
This should also improve performances when writing high number of rows due lower gc pressure.
Benchmark (linux manjaro - i7 6700hq - 16 gb ram) 

Without sync.Pool 
BenchmarkGzipCompression-8   	    3994	    255083 ns/op	  813985 B/op	      19 allocs/op

with sync.Pool (about 12 times faster, no allocations)
BenchmarkGzipCompression-8   	   31036	     39690 ns/op	     138 B/op	       2 allocs/op