### PR TITLE
Use pure Go Zstandard

### DIFF
--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -4,7 +4,7 @@ package compress
 
 import (
 	"bytes"
-	"compress/gzip"
+	"github.com/klauspost/compress/gzip"
 	"github.com/xitongsys/parquet-go/parquet"
 	"io/ioutil"
 )

--- a/compress/zstd.go
+++ b/compress/zstd.go
@@ -3,18 +3,20 @@
 package compress
 
 import (
-	"github.com/DataDog/zstd"
+	"github.com/klauspost/compress/zstd"
 	"github.com/xitongsys/parquet-go/parquet"
 )
 
 func init() {
+	// Create encoder/decoder with default parameters.
+	enc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true))
+	dec, _ := zstd.NewReader(nil)
 	compressors[parquet.CompressionCodec_ZSTD] = &Compressor{
 		Compress: func(buf []byte) []byte {
-			res, _ := zstd.Compress(nil, buf)
-			return res
+			return enc.EncodeAll(buf, nil)
 		},
 		Uncompress: func(buf []byte) (bytes []byte, err error) {
-			return zstd.Decompress(nil, buf)
+			return dec.DecodeAll(buf, nil)
 		},
 	}
 }


### PR DESCRIPTION
So "parquet-go" can truly be "a pure-go implementation" use a pure Go Zstandard enc/decoder.

Sorry, I don't know how to use `dep`. Latest version is recommended.

Also use the faster gzip compressor.