### PR TITLE
Improve the performance of stats computation by reducing branches

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -219,7 +219,8 @@ func TestCmp(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := Cmp(c.numa, c.numb, c.PT, c.CT)
+		funcTable := FindFuncTable(c.PT, c.CT)
+		res := funcTable.LessThan(c.numa, c.numb)
 		if res != c.expect {
 			t.Errorf("Cmp error %v-%v, %v", c.numa, c.numa, c.str)
 		}
@@ -239,7 +240,8 @@ func TestMax(t *testing.T) {
 		{int32(1), int32(2), parquet.TypePtr(parquet.Type_INT32), nil, int32(2)},
 	}
 	for _, data := range testData {
-		res := Max(data.Num1, data.Num2, data.PT, data.CT)
+		funcTable := FindFuncTable(data.PT, data.CT)
+		res := Max(funcTable, data.Num1, data.Num2)
 		if res != data.Expected {
 			t.Errorf("Max err, expect %v, get %v", data.Expected, res)
 		}
@@ -259,7 +261,8 @@ func TestMin(t *testing.T) {
 		{int32(1), int32(2), parquet.TypePtr(parquet.Type_INT32), nil, int32(1)},
 	}
 	for _, data := range testData {
-		res := Min(data.Num1, data.Num2, data.PT, data.CT)
+		funcTable := FindFuncTable(data.PT, data.CT)
+		res := Min(funcTable, data.Num1, data.Num2)
 		if res != data.Expected {
 			t.Errorf("Min err, expect %v, get %v", data.Expected, res)
 		}

--- a/layout/chunk.go
+++ b/layout/chunk.go
@@ -24,6 +24,7 @@ func PagesToChunk(pages []*Page) *Chunk {
 	var maxVal interface{} = pages[0].MaxVal
 	var minVal interface{} = pages[0].MinVal
 	pT, cT := pages[0].Schema.Type, pages[0].Schema.ConvertedType
+	funcTable := common.FindFuncTable(pT, cT)
 
 	for i := 0; i < ln; i++ {
 		if pages[i].Header.DataPageHeader != nil {
@@ -33,8 +34,8 @@ func PagesToChunk(pages []*Page) *Chunk {
 		}
 		totalUncompressedSize += int64(pages[i].Header.UncompressedPageSize) + int64(len(pages[i].RawData)) - int64(pages[i].Header.CompressedPageSize)
 		totalCompressedSize += int64(len(pages[i].RawData))
-		maxVal = common.Max(maxVal, pages[i].MaxVal, pT, cT)
-		minVal = common.Min(minVal, pages[i].MinVal, pT, cT)
+		minVal = common.Min(funcTable, minVal, pages[i].MinVal)
+		maxVal = common.Max(funcTable, maxVal, pages[i].MaxVal)
 	}
 
 	chunk := new(Chunk)
@@ -81,6 +82,7 @@ func PagesToDictChunk(pages []*Page) *Chunk {
 	var maxVal interface{} = pages[1].MaxVal
 	var minVal interface{} = pages[1].MinVal
 	pT, cT := pages[1].Schema.Type, pages[1].Schema.ConvertedType
+	funcTable := common.FindFuncTable(pT, cT)
 
 	for i := 0; i < len(pages); i++ {
 		if pages[i].Header.DataPageHeader != nil {
@@ -91,8 +93,8 @@ func PagesToDictChunk(pages []*Page) *Chunk {
 		totalUncompressedSize += int64(pages[i].Header.UncompressedPageSize) + int64(len(pages[i].RawData)) - int64(pages[i].Header.CompressedPageSize)
 		totalCompressedSize += int64(len(pages[i].RawData))
 		if i > 0 {
-			maxVal = common.Max(maxVal, pages[i].MaxVal, pT, cT)
-			minVal = common.Min(minVal, pages[i].MinVal, pT, cT)
+			minVal = common.Min(funcTable, minVal, pages[i].MinVal)
+			maxVal = common.Max(funcTable, maxVal, pages[i].MaxVal)
 		}
 	}
 

--- a/layout/page.go
+++ b/layout/page.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -81,12 +80,14 @@ func TableToDataPages(table *Table, pageSize int32, compressType parquet.Compres
 		var maxVal interface{} = table.Values[i]
 		var minVal interface{} = table.Values[i]
 
+		funcTable := common.FindFuncTable(pT, cT)
+
 		for j < totalLn && size < pageSize {
 			if table.DefinitionLevels[j] == table.MaxDefinitionLevel {
 				numValues++
-				size += int32(common.SizeOf(reflect.ValueOf(table.Values[j])))
-				maxVal = common.Max(maxVal, table.Values[j], pT, cT)
-				minVal = common.Min(minVal, table.Values[j], pT, cT)
+				var elSize int32
+				minVal, maxVal, elSize = funcTable.MinMaxSize(minVal, maxVal, table.Values[j])
+				size += elSize
 			}
 			j++
 		}


### PR DESCRIPTION
Now instead of checking types every time, we check types exactly once. Also removes reflection checking for sizeof.

This is just shy of a 15% win on the benchmark in #257:

```
name         old time/op    new time/op    delta
WriteCSV-44    10.2ms ± 7%     8.7ms ± 3%  -14.73%  (p=0.000 n=19+19)

name         old alloc/op   new alloc/op   delta
WriteCSV-44    10.7MB ± 0%    10.7MB ± 0%   -0.00%  (p=0.025 n=20+18)

name         old allocs/op  new allocs/op  delta
WriteCSV-44      103k ± 0%      103k ± 0%     ~     (p=0.523 n=20+20)
```