### PR TITLE
Optimize size-of by capturing all types by kind

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -551,19 +551,17 @@ func SizeOf(val reflect.Value) int64 {
 			size += SizeOf(val.MapIndex(keys[i]))
 		}
 		return size
-	}
-	switch val.Type().Name() {
-	case "bool":
+	case reflect.Bool:
 		return 1
-	case "int32":
+	case reflect.Int32:
 		return 4
-	case "int64":
+	case reflect.Int64:
 		return 8
-	case "string":
+	case reflect.String:
 		return int64(val.Len())
-	case "float32":
+	case reflect.Float32:
 		return 4
-	case "float64":
+	case reflect.Float64:
 		return 8
 	}
 	return 4


### PR DESCRIPTION
```
name         old time/op    new time/op    delta
WriteCSV-44    6.19ms ± 2%    5.52ms ± 3%  -10.82%  (p=0.000 n=20+20)

name         old alloc/op   new alloc/op   delta
WriteCSV-44    5.44MB ± 0%    5.44MB ± 0%     ~     (p=0.755 n=19+20)

name         old allocs/op  new allocs/op  delta
WriteCSV-44     61.5k ± 0%     61.5k ± 0%     ~     (all equal)
```