### PR TITLE
Added a specialized implementation of WriteRLEBitPackedHybrid for int32s being written as int64

### DIFF
--- a/layout/page.go
+++ b/layout/page.go
@@ -202,25 +202,17 @@ func (page *Page) DataPageCompress(compressType parquet.CompressionCodec) []byte
 	//definitionLevel//////////////////////////////////
 	var definitionLevelBuf []byte
 	if page.DataTable.MaxDefinitionLevel > 0 {
-		numInterfaces := make([]interface{}, ln)
-		for i := 0; i < ln; i++ {
-			numInterfaces[i] = int64(page.DataTable.DefinitionLevels[i])
-		}
-		definitionLevelBuf = encoding.WriteRLEBitPackedHybrid(numInterfaces,
-			int32(common.BitNum(uint64(page.DataTable.MaxDefinitionLevel))),
-			parquet.Type_INT64)
+		definitionLevelBuf = encoding.WriteRLEBitPackedHybridInt32(
+			page.DataTable.DefinitionLevels,
+			int32(common.BitNum(uint64(page.DataTable.MaxDefinitionLevel))))
 	}
 
 	//repetitionLevel/////////////////////////////////
 	var repetitionLevelBuf []byte
 	if page.DataTable.MaxRepetitionLevel > 0 {
-		numInterfaces := make([]interface{}, ln)
-		for i := 0; i < ln; i++ {
-			numInterfaces[i] = int64(page.DataTable.RepetitionLevels[i])
-		}
-		repetitionLevelBuf = encoding.WriteRLEBitPackedHybrid(numInterfaces,
-			int32(common.BitNum(uint64(page.DataTable.MaxRepetitionLevel))),
-			parquet.Type_INT64)
+		repetitionLevelBuf = encoding.WriteRLEBitPackedHybridInt32(
+			page.DataTable.RepetitionLevels,
+			int32(common.BitNum(uint64(page.DataTable.MaxRepetitionLevel))))
 	}
 
 	//dataBuf = repetitionBuf + definitionBuf + valuesRawBuf


### PR DESCRIPTION
This case is used in writing the definition levels and repetition levels for each page, and thus is performance sensitive.

```
name         old time/op    new time/op    delta
WriteCSV-44    6.19ms ± 2%    5.32ms ± 2%  -14.01%  (p=0.000 n=20+17)

name         old alloc/op   new alloc/op   delta
WriteCSV-44    5.44MB ± 0%    4.44MB ± 0%  -18.44%  (p=0.000 n=19+18)

name         old allocs/op  new allocs/op  delta
WriteCSV-44     61.5k ± 0%     21.4k ± 0%  -65.24%  (p=0.000 n=20+20)
```