### PR TITLE
Remove extra alloc + copy in WriteDeltaLengthByteArray

### DIFF
--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -368,15 +368,13 @@ func WriteDeltaINT64(nums []interface{}) []byte {
 
 func WriteDeltaLengthByteArray(arrays []interface{}) []byte {
 	ln := len(arrays)
-	res := make([]byte, 0)
 	lengthArray := make([]interface{}, ln)
 	for i := 0; i < ln; i++ {
 		array := reflect.ValueOf(arrays[i]).String()
 		lengthArray[i] = int32(len(array))
 	}
 
-	lengthBuf := WriteDeltaINT32(lengthArray)
-	res = append(res, lengthBuf...)
+	res := WriteDeltaINT32(lengthArray)
 
 	for i := 0; i < ln; i++ {
 		array := reflect.ValueOf(arrays[i]).String()

--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -378,7 +378,7 @@ func WriteDeltaLengthByteArray(arrays []interface{}) []byte {
 
 	for i := 0; i < ln; i++ {
 		array := reflect.ValueOf(arrays[i]).String()
-		res = append(res, []byte(array)...)
+		res = append(res, array...)
 	}
 	return res
 }


### PR DESCRIPTION
No benchmark this time, just noticed this one by sight.