### PR TITLE
Use stdlib function in place of common.BitNum

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -324,15 +324,6 @@ func HeadToUpper(str string) string {
 	return "P_" + str
 }
 
-//Get the number of bits needed by the num; 0 needs 0, 1 need 1, 2 need 2, 3 need 2 ....
-func BitNum(num uint64) uint64 {
-	var bitn uint64 = 0
-	for ; num != 0; num >>= 1 {
-		bitn++
-	}
-	return bitn
-}
-
 func CmpIntBinary(as string, bs string, order string, signed bool) bool {
 	abs, bbs := []byte(as), []byte(bs)
 	la, lb := len(abs), len(bbs)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -30,26 +30,6 @@ func TestHeadToUpper(t *testing.T) {
 	}
 }
 
-func TestBitNum(t *testing.T) {
-	testData := []struct {
-		Num      uint64
-		Expected uint64
-	}{
-		{0, 0},
-		{1, 1},
-		{2, 2},
-		{3, 2},
-		{8, 4},
-	}
-
-	for _, data := range testData {
-		res := BitNum(data.Num)
-		if res != data.Expected {
-			t.Errorf("BitNum err, expect %v, get %v", data.Expected, res)
-		}
-	}
-}
-
 func TestCmpIntBinary(t *testing.T) {
 	cases := []struct {
 		numa int32

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -3,9 +3,9 @@ package encoding
 import (
 	"bytes"
 	"fmt"
+	"math/bits"
 	"testing"
 
-	. "github.com/xitongsys/parquet-go/common"
 	"github.com/xitongsys/parquet-go/parquet"
 )
 
@@ -135,7 +135,7 @@ func TestReadRLEBitPackedHybrid(t *testing.T) {
 	for _, data := range testData {
 		maxVal := uint64(data[len(data)-1].(int64))
 
-		res, err := ReadRLEBitPackedHybrid(bytes.NewReader(WriteRLEBitPackedHybrid(data, int32(BitNum(maxVal)), parquet.Type_INT64)), uint64(BitNum(maxVal)), 0)
+		res, err := ReadRLEBitPackedHybrid(bytes.NewReader(WriteRLEBitPackedHybrid(data, int32(bits.Len64(maxVal)), parquet.Type_INT64)), uint64(bits.Len64(maxVal)), 0)
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadRLEBitpackedHybrid error, expect %v, get %v, err info:%v", data, res, err)
 		}
@@ -187,7 +187,7 @@ func TestReadBitPacked(t *testing.T) {
 	for _, data := range testData {
 		ln := len(data)
 		header := ((ln/8)<<1 | 1)
-		bitWidth := BitNum(uint64(data[ln-1].(int)))
+		bitWidth := uint64(bits.Len(uint(data[ln-1].(int))))
 		res, _ := ReadBitPacked(bytes.NewReader(WriteBitPacked(data, int64(bitWidth), false)), uint64(header), bitWidth)
 		if fmt.Sprintf("%v", res) != fmt.Sprintf("%v", data) {
 

--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -3,9 +3,9 @@ package encoding
 import (
 	"bytes"
 	"encoding/binary"
+	"math/bits"
 	"reflect"
 
-	"github.com/xitongsys/parquet-go/common"
 	"github.com/xitongsys/parquet-go/parquet"
 )
 
@@ -129,7 +129,7 @@ func WritePlainFIXED_LEN_BYTE_ARRAY(arrays []interface{}) []byte {
 }
 
 func WriteUnsignedVarInt(num uint64) []byte {
-	byteNum := (common.BitNum(uint64(num)) + 6) / 7
+	byteNum := (bits.Len64(uint64(num)) + 6) / 7
 	if byteNum == 0 {
 		return make([]byte, 1)
 	}
@@ -326,7 +326,7 @@ func WriteDeltaINT32(nums []interface{}) []byte {
 					maxValue = blockBuf[k].(int32)
 				}
 			}
-			bitWidths[j] = byte(common.BitNum(uint64(maxValue)))
+			bitWidths[j] = byte(bits.Len32(uint32(maxValue)))
 		}
 
 		var minDeltaZigZag uint64 = uint64((minDelta >> 31) ^ (minDelta << 1))
@@ -384,7 +384,7 @@ func WriteDeltaINT64(nums []interface{}) []byte {
 					maxValue = blockBuf[k].(int64)
 				}
 			}
-			bitWidths[j] = byte(common.BitNum(uint64(maxValue)))
+			bitWidths[j] = byte(bits.Len64(uint64(maxValue)))
 		}
 
 		var minDeltaZigZag uint64 = uint64((minDelta >> 63) ^ (minDelta << 1))

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -2,9 +2,9 @@ package encoding
 
 import (
 	"encoding/json"
+	"math/bits"
 	"testing"
 
-	. "github.com/xitongsys/parquet-go/common"
 	"github.com/xitongsys/parquet-go/parquet"
 )
 
@@ -77,7 +77,7 @@ func TestWriteRLE(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WriteRLE(data.nums, int32(BitNum(uint64(data.nums[len(data.nums)-1].(int64)))), parquet.Type_INT64)
+		res := WriteRLE(data.nums, int32(bits.Len64(uint64(data.nums[len(data.nums)-1].(int64)))), parquet.Type_INT64)
 		if string(res) != string(data.expected) {
 			t.Errorf("WriteRLE error, expect %v, get %v", data.expected, res)
 		}
@@ -94,7 +94,7 @@ func TestWriteBitPacked(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WriteBitPacked(data.nums, int64(BitNum(uint64(data.nums[len(data.nums)-1].(int)))), true)
+		res := WriteBitPacked(data.nums, int64(bits.Len64(uint64(data.nums[len(data.nums)-1].(int)))), true)
 		if string(res) != string(data.expected) {
 			t.Errorf("WriteRLE error, expect %v, get %v", data.expected, res)
 		}

--- a/layout/dictpage.go
+++ b/layout/dictpage.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"context"
+	"math/bits"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/xitongsys/parquet-go/common"
@@ -144,7 +145,7 @@ func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bi
 	if page.DataTable.MaxDefinitionLevel > 0 {
 		definitionLevelBuf = encoding.WriteRLEBitPackedHybridInt32(
 			page.DataTable.DefinitionLevels,
-			int32(common.BitNum(uint64(page.DataTable.MaxDefinitionLevel))))
+			int32(bits.Len32(uint32(page.DataTable.MaxDefinitionLevel))))
 	}
 
 	//repetitionLevel/////////////////////////////////
@@ -152,7 +153,7 @@ func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bi
 	if page.DataTable.MaxRepetitionLevel > 0 {
 		repetitionLevelBuf = encoding.WriteRLEBitPackedHybridInt32(
 			page.DataTable.RepetitionLevels,
-			int32(common.BitNum(uint64(page.DataTable.MaxRepetitionLevel))))
+			int32(bits.Len32(uint32(page.DataTable.MaxRepetitionLevel))))
 	}
 
 	//dataBuf = repetitionBuf + definitionBuf + valuesRawBuf


### PR DESCRIPTION
No measurably performance difference. However, if this function ever were a bottleneck, I'd expect the stdlib variant to perform faster as the compiler rewrites it to a `bsrq` instructions.