### PR TITLE
Use specialized int32 rle in dict pages

### DIFF
--- a/layout/dictpage.go
+++ b/layout/dictpage.go
@@ -85,7 +85,7 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize int32, bi
 
 		var maxVal interface{} = table.Values[i]
 		var minVal interface{} = table.Values[i]
-		values := make([]interface{}, 0)
+		values := make([]int32, 0)
 
 		funcTable := common.FindFuncTable(pT, cT)
 
@@ -114,7 +114,6 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize int32, bi
 		page.DataTable.Path = table.Path
 		page.DataTable.MaxDefinitionLevel = table.MaxDefinitionLevel
 		page.DataTable.MaxRepetitionLevel = table.MaxRepetitionLevel
-		page.DataTable.Values = values
 		page.DataTable.DefinitionLevels = table.DefinitionLevels[i:j]
 		page.DataTable.RepetitionLevels = table.RepetitionLevels[i:j]
 		page.MaxVal = maxVal
@@ -124,7 +123,7 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize int32, bi
 		page.Path = table.Path
 		page.Info = table.Info
 
-		page.DictDataPageCompress(compressType, bitWidth)
+		page.DictDataPageCompress(compressType, bitWidth, values)
 
 		totSize += int64(len(page.RawData))
 		res = append(res, page)
@@ -134,10 +133,10 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize int32, bi
 }
 
 //Compress the data page to parquet file
-func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bitWidth int32) []byte {
+func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bitWidth int32, values []int32) []byte {
 	//values////////////////////////////////////////////
 	valuesRawBuf := []byte{byte(bitWidth)}
-	valuesRawBuf = append(valuesRawBuf, encoding.WriteRLE(page.DataTable.Values, bitWidth, parquet.Type_INT32)...)
+	valuesRawBuf = append(valuesRawBuf, encoding.WriteRLEInt32(values, bitWidth)...)
 
 	//definitionLevel//////////////////////////////////
 	var definitionLevelBuf []byte
@@ -184,32 +183,4 @@ func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bi
 	page.RawData = res
 
 	return res
-}
-
-//Convert a table to dict page
-func TableToDictPage(table *Table, pageSize int32, compressType parquet.CompressionCodec) (*Page, int64) {
-	var totSize int64 = 0
-	totalLn := len(table.Values)
-
-	page := NewDataPage()
-	page.PageSize = pageSize
-	page.Header.DataPageHeader.NumValues = int32(totalLn)
-	page.Header.Type = parquet.PageType_DICTIONARY_PAGE
-
-	page.DataTable = new(Table)
-	page.DataTable.RepetitionType = table.RepetitionType
-	page.DataTable.Path = table.Path
-	page.DataTable.MaxDefinitionLevel = table.MaxDefinitionLevel
-	page.DataTable.MaxRepetitionLevel = table.MaxRepetitionLevel
-	page.DataTable.Values = table.Values
-	page.DataTable.DefinitionLevels = table.DefinitionLevels
-	page.DataTable.RepetitionLevels = table.RepetitionLevels
-	page.Schema = table.Schema
-	page.CompressType = compressType
-	page.Path = table.Path
-	page.Info = table.Info
-
-	page.DictPageCompress(compressType, *page.Schema.Type)
-	totSize += int64(len(page.RawData))
-	return page, totSize
 }


### PR DESCRIPTION
Also remove some dead code

```
name                        old time/op    new time/op    delta
WriteCSVPlainDictionary-44    17.0ms ± 2%    14.1ms ± 4%  -17.42%  (p=0.000 n=20+20)

name                        old alloc/op   new alloc/op   delta
WriteCSVPlainDictionary-44    4.86MB ± 0%    3.17MB ± 0%  -34.85%  (p=0.000 n=19+20)

name                        old allocs/op  new allocs/op  delta
WriteCSVPlainDictionary-44     22.0k ± 0%     21.8k ± 0%   -0.65%  (p=0.000 n=20+18)
```