### PR TITLE
Re-organize hash table access in dict page for performance

### DIFF
--- a/layout/dictpage.go
+++ b/layout/dictpage.go
@@ -95,11 +95,14 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize int32, bi
 				var elSize int32
 				minVal, maxVal, elSize = funcTable.MinMaxSize(minVal, maxVal, table.Values[j])
 				size += elSize
-				if _, ok := dictRec.DictMap[table.Values[j]]; !ok {
+				if idx, ok := dictRec.DictMap[table.Values[j]]; ok {
+					values = append(values, idx)
+				} else {
 					dictRec.DictSlice = append(dictRec.DictSlice, table.Values[j])
-					dictRec.DictMap[table.Values[j]] = int32(len(dictRec.DictSlice) - 1)
+					idx := int32(len(dictRec.DictSlice) - 1)
+					dictRec.DictMap[table.Values[j]] = idx
+					values = append(values, idx)
 				}
-				values = append(values, int32(dictRec.DictMap[table.Values[j]]))
 			}
 			j++
 		}


### PR DESCRIPTION
```
name                        old time/op    new time/op    delta
WriteCSVPlainDictionary-44    14.0ms ± 4%    11.2ms ± 3%  -19.82%  (p=0.000 n=19+20)

name                        old alloc/op   new alloc/op   delta
WriteCSVPlainDictionary-44    3.17MB ± 0%    3.17MB ± 0%   -0.00%  (p=0.020 n=19+20)

name                        old allocs/op  new allocs/op  delta
WriteCSVPlainDictionary-44     21.8k ± 0%     21.8k ± 0%   -0.00%  (p=0.004 n=20+20)
```