### PR TITLE
Fix race condition

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -227,8 +227,10 @@ func (self *ParquetWriter) flushObjs() error {
 						table.Info.Encoding == parquet.Encoding_RLE_DICTIONARY {
 
 						func() {
-							lock.Lock()
-							defer lock.Unlock()
+							if self.NP > 1 {
+								lock.Lock()
+								defer lock.Unlock()
+							}
 							if _, ok := self.DictRecs[name]; !ok {
 								self.DictRecs[name] = layout.NewDictRec(*table.Schema.Type)
 							}


### PR DESCRIPTION
1. Lock can be never unlocked if panic happens inside `TableToDictDataPages`.
2. Don't use lock on parallelism = 1.

Related issues:
https://github.com/xitongsys/parquet-go/issues/256
https://github.com/xitongsys/parquet-go-source/issues/17

Disclaimer: I have very limited go experience.