### PR TITLE
reader: use io.ReadFull instead of Reader.Read to read footer length

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -123,7 +123,7 @@ func (self *ParquetReader) GetFooterSize() (uint32, error) {
 	if _, err = self.PFile.Seek(-8, io.SeekEnd); err != nil {
 		return 0, err
 	}
-	if _, err = self.PFile.Read(buf); err != nil {
+	if _, err = io.ReadFull(self.PFile, buf); err != nil {
 		return 0, err
 	}
 	size := binary.LittleEndian.Uint32(buf)


### PR DESCRIPTION
use `io.ReadFull` instead of reader.Read to make sure exactly n bytes is read. In s3 environment, the `Reader.Read` call may not return enough bytes since the [interface comment of Reader.Read](https://pkg.go.dev/io/#Reader) allow this behavior.