### PR TITLE
Added omitstats option to field tags to reduce file sizes for some scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ BYTE_ARRAY, UTF8
 
 * Some platforms don't support all kinds of encodings. If you are not sure, just use PLAIN and PLAIN_DICTIONARY.
 * If the fields have many different values, please don't use PLAIN_DICTIONARY encoding. Because it will record all the different values in a map which will use a lot of memory. Actually it use a 32-bit integer to store the index. It can not used if your unique values number is larger than 32-bit.
-* Large array values may be duplicated as min and max values in page stats, significantly increasing file size. If stats are not useful for such a column, they can be omitted from written files by adding `omitstats=true` to column tag.
+* Large array values may be duplicated as min and max values in page stats, significantly increasing file size. If stats are not useful for such a field, they can be omitted from written files by adding `omitstats=true` to a field tag.
 
 ## Repetition Type
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ BYTE_ARRAY, UTF8
 
 * Some platforms don't support all kinds of encodings. If you are not sure, just use PLAIN and PLAIN_DICTIONARY.
 * If the fields have many different values, please don't use PLAIN_DICTIONARY encoding. Because it will record all the different values in a map which will use a lot of memory. Actually it use a 32-bit integer to store the index. It can not used if your unique values number is larger than 32-bit.
+* Large array values may be duplicated as min and max values in page stats, significantly increasing file size. If stats are not useful for such a column, they can be omitted from written files by adding `omitstats=true` to column tag.
 
 ## Repetition Type
 

--- a/common/common.go
+++ b/common/common.go
@@ -44,6 +44,10 @@ type Tag struct {
 	KeyEncoding   parquet.Encoding
 	ValueEncoding parquet.Encoding
 
+	OmitStats      bool
+	KeyOmitStats   bool
+	ValueOmitStats bool
+
 	RepetitionType      parquet.FieldRepetitionType
 	KeyRepetitionType   parquet.FieldRepetitionType
 	ValueRepetitionType parquet.FieldRepetitionType
@@ -76,6 +80,14 @@ func StringToTag(tag string) *Tag {
 				panic(err)
 			}
 			return int32(valInt)
+		}
+
+		valBoolean := func() bool {
+			valBoolean, err := strconv.ParseBool(val)
+			if err != nil {
+				panic(err)
+			}
+			return valBoolean
 		}
 
 		switch key {
@@ -122,6 +134,12 @@ func StringToTag(tag string) *Tag {
 			mp.ExName = val
 		case "inname":
 			mp.InName = val
+		case "omitstats":
+			mp.OmitStats = valBoolean()
+		case "keyomitstats":
+			mp.KeyOmitStats = valBoolean()
+		case "valueomitstats":
+			mp.ValueOmitStats = valBoolean()
 		case "repetitiontype":
 			switch strings.ToLower(val) {
 			case "repeated":
@@ -267,6 +285,7 @@ func GetKeyTagMap(src *Tag) *Tag {
 	res.Precision = src.KeyPrecision
 	res.FieldID = src.KeyFieldID
 	res.Encoding = src.KeyEncoding
+	res.OmitStats = src.KeyOmitStats
 	res.RepetitionType = parquet.FieldRepetitionType_REQUIRED
 	return res
 }
@@ -283,6 +302,7 @@ func GetValueTagMap(src *Tag) *Tag {
 	res.Precision = src.ValuePrecision
 	res.FieldID = src.ValueFieldID
 	res.Encoding = src.ValueEncoding
+	res.OmitStats = src.ValueOmitStats
 	res.RepetitionType = src.ValueRepetitionType
 	return res
 }


### PR DESCRIPTION
Added an option `omitstats` to the field tag to prevent writing min and max stats to page footers. This can dramatically reduce the size of files that carry large arrays of data. Such stats are not generally useful for array data.

In my scenario, I am including large blob content as a field, up to 100MB. In those cases, the content was duplicated twice as min and max values in the page stats.