### PR TITLE
layout: fix read byte not full from s3

### DIFF
--- a/encoding/binaryread.go
+++ b/encoding/binaryread.go
@@ -9,7 +9,7 @@ import (
 
 func BinaryReadINT32(r io.Reader, nums []interface{}) error {
 	buf := make([]byte, len(nums)*4)
-	n, err := r.Read(buf)
+	n, err := io.ReadFull(r, buf)
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func BinaryReadINT32(r io.Reader, nums []interface{}) error {
 
 func BinaryReadINT64(r io.Reader, nums []interface{}) error {
 	buf := make([]byte, len(nums)*8)
-	n, err := r.Read(buf)
+	n, err := io.ReadFull(r, ,buf)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func BinaryReadINT64(r io.Reader, nums []interface{}) error {
 
 func BinaryReadFLOAT32(r io.Reader, nums []interface{}) error {
 	buf := make([]byte, len(nums)*4)
-	n, err := r.Read(buf)
+	n, err := io.ReadFull(r, buf)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func BinaryReadFLOAT32(r io.Reader, nums []interface{}) error {
 
 func BinaryReadFLOAT64(r io.Reader, nums []interface{}) error {
 	buf := make([]byte, len(nums)*8)
-	n, err := r.Read(buf)
+	n, err := io.ReadFull(r, buf)
 	if err != nil {
 		return err
 	}

--- a/layout/page.go
+++ b/layout/page.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/bits"
 	"strings"
 
@@ -407,7 +408,7 @@ func ReadPageRawData(thriftReader *thrift.TBufferedTransport, schemaHandler *sch
 
 	compressedPageSize := pageHeader.GetCompressedPageSize()
 	buf := make([]byte, compressedPageSize)
-	if _, err := thriftReader.Read(buf); err != nil {
+	if _, err := io.ReadFull(thriftReader, buf); err != nil {
 		return nil, err
 	}
 
@@ -728,13 +729,13 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 		definitionLevelsBuf := make([]byte, dll)
 		dataBuf := make([]byte, compressedPageSize-rll-dll)
 
-		if _, err = thriftReader.Read(repetitionLevelsBuf); err != nil {
+		if _, err = io.ReadFull(thriftReader, repetitionLevelsBuf); err != nil {
 			return nil, 0, 0, err
 		}
-		if _, err = thriftReader.Read(definitionLevelsBuf); err != nil {
+		if _, err = io.ReadFull(thriftReader, definitionLevelsBuf); err != nil {
 			return nil, 0, 0, err
 		}
-		if _, err = thriftReader.Read(dataBuf); err != nil {
+		if _, err = io.ReadFull(thriftReader, dataBuf); err != nil {
 			return nil, 0, 0, err
 		}
 
@@ -762,7 +763,7 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 
 	} else {
 		buf = make([]byte, compressedPageSize)
-		if _, err = thriftReader.Read(buf); err != nil {
+		if _, err = io.ReadFull(thriftReader, buf); err != nil {
 			return nil, 0, 0, err
 		}
 		codec := colMetaData.GetCodec()

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -5,16 +5,16 @@ import (
 	"encoding/binary"
 	"io"
 	"reflect"
-	"sync"
 	"strings"
+	"sync"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/xitongsys/parquet-go/common"
 	"github.com/xitongsys/parquet-go/layout"
 	"github.com/xitongsys/parquet-go/marshal"
-	"github.com/xitongsys/parquet-go/source"
-	"github.com/xitongsys/parquet-go/schema"
 	"github.com/xitongsys/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/source"
 )
 
 type ParquetReader struct {
@@ -26,8 +26,8 @@ type ParquetReader struct {
 	ColumnBuffers map[string]*ColumnBufferType
 
 	//One reader can only read one type objects
-	ObjType			reflect.Type
-	ObjPartialType	reflect.Type
+	ObjType        reflect.Type
+	ObjPartialType reflect.Type
 }
 
 //Create a parquet reader: obj is a object with schema tags or a JSON schema string
@@ -55,7 +55,7 @@ func NewParquetReader(pFile source.ParquetFile, obj interface{}, np int64) (*Par
 			}
 		}
 
-	}else{
+	} else {
 		res.SchemaHandler = schema.NewSchemaHandlerFromSchemaList(res.Footer.Schema)
 	}
 
@@ -80,7 +80,6 @@ func (self *ParquetReader) SetSchemaHandlerFromJSON(jsonSchema string) error {
 		return err
 	}
 
-	
 	self.RenameSchema()
 	for i := 0; i < len(self.SchemaHandler.SchemaElements); i++ {
 		schemaElement := self.SchemaHandler.SchemaElements[i]
@@ -199,7 +198,7 @@ func (self *ParquetReader) Read(dstInterface interface{}) error {
 
 // Read maxReadNumber objects
 func (self *ParquetReader) ReadByNumber(maxReadNumber int) ([]interface{}, error) {
-	var err error 
+	var err error
 	if self.ObjType == nil {
 		if self.ObjType, err = self.SchemaHandler.GetType(self.SchemaHandler.GetRootInName()); err != nil {
 			return nil, err
@@ -229,13 +228,13 @@ func (self *ParquetReader) ReadPartial(dstInterface interface{}, prefixPath stri
 	if err != nil {
 		return err
 	}
-	
+
 	return self.read(dstInterface, prefixPath)
 }
 
-// Read maxReadNumber partial objects 
+// Read maxReadNumber partial objects
 func (self *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath string) ([]interface{}, error) {
-	var err error 
+	var err error
 	if self.ObjPartialType == nil {
 		if self.ObjPartialType, err = self.SchemaHandler.GetType(prefixPath); err != nil {
 			return nil, err
@@ -327,7 +326,7 @@ func (self *ParquetReader) read(dstInterface interface{}, prefixPath string) err
 		}
 		wg.Add(1)
 		go func(b, e, index int) {
-			defer func(){
+			defer func() {
 				wg.Done()
 			}()
 


### PR DESCRIPTION
thriftReader may not read full bytes from s3 backend. use` io.ReadFull` instead.