### PR TITLE
Add s3 support to parquet tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/apache/thrift v0.13.1-0.20201008052519-daf620915714
+	github.com/aws/aws-sdk-go v1.30.19 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.1

--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/xitongsys/parquet-go-source/local"
 	"github.com/xitongsys/parquet-go/reader"
@@ -23,14 +24,14 @@ func main() {
 
 	fr, err := local.NewLocalFileReader(*fileName)
 	if err != nil {
-		fmt.Println("Can't open file ", *fileName)
-		return
+		fmt.Fprintf(os.Stderr, "Can't open file %s\n", *fileName)
+		os.Exit(1)
 	}
 
 	pr, err := reader.NewParquetReader(fr, nil, 1)
 	if err != nil {
-		fmt.Println("Can't create parquet reader ", err)
-		return
+		fmt.Fprintf(os.Stderr, "Can't create parquet reader: %s\n", err)
+		os.Exit(1)
 	}
 
 	switch *cmd {
@@ -54,14 +55,14 @@ func main() {
 
 			res, err := pr.ReadByNumber(cnt)
 			if err != nil {
-				fmt.Println("Can't cat ", err)
-				return
+				fmt.Fprintf(os.Stderr, "Can't cat: %s\n", err)
+				os.Exit(1)
 			}
 
 			jsonBs, err := json.Marshal(res)
 			if err != nil {
-				fmt.Println("Can't to json ", err)
-				return
+				fmt.Fprintf(os.Stderr, "Can't to json: %s\n", err)
+				os.Exit(1)
 			}
 
 			fmt.Println(string(jsonBs))
@@ -70,7 +71,8 @@ func main() {
 		}
 
 	default:
-		fmt.Println("Unknown command")
+		fmt.Fprintf(os.Stderr, "Unknown command %s\n", *cmd)
+		os.Exit(1)
 	}
 
 }

--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -29,8 +29,15 @@ func main() {
 	withPrettySize := flag.Bool("pretty", false, "show pretty size")
 	uncompressedSize := flag.Bool("uncompressed", false, "show uncompressed size")
 	catCount := flag.Int("count", 1000, "max count to cat. If it is nil, only show first 1000 records.")
+	schemaFormat := flag.String("schema-format", "json", "schema format go/json (default to JSON schema)")
 
 	flag.Parse()
+
+	// validate schema output format
+	if *schemaFormat != "json" && *schemaFormat != "go" {
+		fmt.Fprintf(os.Stderr, "schema format can only be json or go\n")
+		os.Exit(1)
+	}
 
 	// validate file name
 	if *fileName == "" {
@@ -89,10 +96,11 @@ func main() {
 	switch *cmd {
 	case "schema":
 		tree := schematool.CreateSchemaTree(pr.SchemaHandler.SchemaElements)
-		fmt.Println("----- Go struct -----")
-		fmt.Printf("%s\n", tree.OutputStruct(*withTags))
-		fmt.Println("----- Json schema -----")
-		fmt.Printf("%s\n", tree.OutputJsonSchema())
+		if *schemaFormat == "go" {
+			fmt.Printf("%s\n", tree.OutputStruct(*withTags))
+		} else {
+			fmt.Printf("%s\n", tree.OutputJsonSchema())
+		}
 	case "rowcount":
 		fmt.Println(pr.GetNumRows())
 	case "size":


### PR DESCRIPTION
Add s3 support to parquet-tools so one does not have to download S3 object to local for inspection, this can be tested by using data from https://pro.dp.la/developers/bulk-download, the parquet file used below is 4.2 GB with 14M rows:

```
$ time go run tool/parquet-tools/parquet-tools.go -cmd rowcount -file s3://dpla-provider-export/2021/03/all.parquet/part-00000-56ba8f11-cb30-4bc3-8f6d-dd26c0dd1f06-c000.snappy.parquet
13970671

real    0m20.480s
user    0m1.212s
sys     0m0.710s
```

Other changes are to make parquet-tools CLI friendly so it can be used in bash scripts:
1. exit 1 whenever there is an error
2. error message to stderr
3. new command parameter to output go struct ***or*** JSON schema.