### PR TITLE
Consistent Receiver Nomenclature

### DIFF
--- a/layout/table.go
+++ b/layout/table.go
@@ -49,7 +49,7 @@ type Table struct {
 }
 
 //Merge several tables to one table(the first table)
-func (self *Table) Merge(tables ...*Table) {
+func (t *Table) Merge(tables ...*Table) {
 	ln := len(tables)
 	if ln <= 0 {
 		return
@@ -58,46 +58,46 @@ func (self *Table) Merge(tables ...*Table) {
 		if tables[i] == nil {
 			continue
 		}
-		self.Values = append(self.Values, tables[i].Values...)
-		self.RepetitionLevels = append(self.RepetitionLevels, tables[i].RepetitionLevels...)
-		self.DefinitionLevels = append(self.DefinitionLevels, tables[i].DefinitionLevels...)
-		if tables[i].MaxDefinitionLevel > self.MaxDefinitionLevel {
-			self.MaxDefinitionLevel = tables[i].MaxDefinitionLevel
+		t.Values = append(t.Values, tables[i].Values...)
+		t.RepetitionLevels = append(t.RepetitionLevels, tables[i].RepetitionLevels...)
+		t.DefinitionLevels = append(t.DefinitionLevels, tables[i].DefinitionLevels...)
+		if tables[i].MaxDefinitionLevel > t.MaxDefinitionLevel {
+			t.MaxDefinitionLevel = tables[i].MaxDefinitionLevel
 		}
-		if tables[i].MaxRepetitionLevel > self.MaxRepetitionLevel {
-			self.MaxRepetitionLevel = tables[i].MaxRepetitionLevel
+		if tables[i].MaxRepetitionLevel > t.MaxRepetitionLevel {
+			t.MaxRepetitionLevel = tables[i].MaxRepetitionLevel
 		}
 	}
 }
 
-func (self *Table) Pop(numRows int64) *Table {
-	res := NewTableFromTable(self)
+func (t *Table) Pop(numRows int64) *Table {
+	res := NewTableFromTable(t)
 	endIndex := int64(0)
-	ln := int64(len(self.Values))
+	ln := int64(len(t.Values))
 	i, num := int64(0), int64(-1)
 	for i = 0; i < ln; i++ {
-		if self.RepetitionLevels[i] == 0 {
+		if t.RepetitionLevels[i] == 0 {
 			num++
 			if num >= numRows {
 				break
 			}
 		}
-		if res.MaxRepetitionLevel < self.RepetitionLevels[i] {
-			res.MaxRepetitionLevel = self.RepetitionLevels[i]
+		if res.MaxRepetitionLevel < t.RepetitionLevels[i] {
+			res.MaxRepetitionLevel = t.RepetitionLevels[i]
 		}
-		if res.MaxDefinitionLevel < self.DefinitionLevels[i] {
-			res.MaxDefinitionLevel = self.DefinitionLevels[i]
+		if res.MaxDefinitionLevel < t.DefinitionLevels[i] {
+			res.MaxDefinitionLevel = t.DefinitionLevels[i]
 		}
 	}
 	endIndex = i
 
-	res.RepetitionLevels = self.RepetitionLevels[:endIndex]
-	res.DefinitionLevels = self.DefinitionLevels[:endIndex]
-	res.Values = self.Values[:endIndex]
+	res.RepetitionLevels = t.RepetitionLevels[:endIndex]
+	res.DefinitionLevels = t.DefinitionLevels[:endIndex]
+	res.Values = t.Values[:endIndex]
 
-	self.RepetitionLevels = self.RepetitionLevels[endIndex:]
-	self.DefinitionLevels = self.DefinitionLevels[endIndex:]
-	self.Values = self.Values[endIndex:]
+	t.RepetitionLevels = t.RepetitionLevels[endIndex:]
+	t.DefinitionLevels = t.DefinitionLevels[endIndex:]
+	t.Values = t.Values[endIndex:]
 
 	return res
 }

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -36,16 +36,16 @@ func NewNodeBuf(ln int) *NodeBufType {
 	return nodeBuf
 }
 
-func (self *NodeBufType) GetNode() *Node {
-	if self.Index >= len(self.Buf) {
-		self.Buf = append(self.Buf, new(Node))
+func (nbt *NodeBufType) GetNode() *Node {
+	if nbt.Index >= len(nbt.Buf) {
+		nbt.Buf = append(nbt.Buf, new(Node))
 	}
-	self.Index++
-	return self.Buf[self.Index-1]
+	nbt.Index++
+	return nbt.Buf[nbt.Index-1]
 }
 
-func (self *NodeBufType) Reset() {
-	self.Index = 0
+func (nbt *NodeBufType) Reset() {
+	nbt.Index = 0
 }
 
 ////////for improve performance///////////////////////////////////

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -42,7 +42,7 @@ func NewCSVWriter(md []string, pfile source.ParquetFile, np int64) (*CSVWriter, 
 }
 
 //Write string values to parquet file
-func (self *CSVWriter) WriteString(recsi interface{}) error {
+func (w *CSVWriter) WriteString(recsi interface{}) error {
 	recs := recsi.([]*string)
 	lr := len(recs)
 	rec := make([]interface{}, lr)
@@ -50,13 +50,13 @@ func (self *CSVWriter) WriteString(recsi interface{}) error {
 		rec[i] = nil
 		if recs[i] != nil {
 			rec[i] = types.StrToParquetType(*recs[i],
-				self.SchemaHandler.SchemaElements[i+1].Type,
-				self.SchemaHandler.SchemaElements[i+1].ConvertedType,
-				int(self.SchemaHandler.SchemaElements[i+1].GetTypeLength()),
-				int(self.SchemaHandler.SchemaElements[i+1].GetScale()),
+				w.SchemaHandler.SchemaElements[i+1].Type,
+				w.SchemaHandler.SchemaElements[i+1].ConvertedType,
+				int(w.SchemaHandler.SchemaElements[i+1].GetTypeLength()),
+				int(w.SchemaHandler.SchemaElements[i+1].GetScale()),
 			)
 		}
 	}
 
-	return self.Write(rec)
+	return w.Write(rec)
 }


### PR DESCRIPTION
This changes receiver variables throughout the project to reflect the name of the receiver, not a generic name like `self`.

It looks like newer parts of the codebase don't use `self` anymore, this makes it all consistent.

If you would prefer that I put these up as individual per-package pull requests, I'm happy to do so. I could also squash into a single commit.

https://github.com/golang/go/wiki/CodeReviewComments#receiver-names