### PR TITLE
Add metadata command to parquet-tools

### DIFF
--- a/tool/parquet-tools/README.md
+++ b/tool/parquet-tools/README.md
@@ -7,13 +7,19 @@ cd parquet-tools && go build parquet-tools
 
 ## Description
 ### -cmd
-schema/size/rowcount
+schema/size/rowcount/cat/metadata
+### -count
+max count to cat. If it is nil, only show first 1000 records. (default 1000)
 ### -file
-parquet file name;
+parquet file name, supprt `file://` and `s3://` scheme
+### -pretty
+show pretty size
+###  -schema-format
+schema format, go/json. (default "json")
 ### -tag
 print the go struct tags; default is false;
-### -cat
-cat records of parquet file.
+### -uncompressed
+show uncompressed size
 
 ## Example
 
@@ -21,17 +27,6 @@ cat records of parquet file.
 
 ```bash
 bash$ ./parquet-tools -cmd schema -file a.parquet -tag false
-bash$
------ Go struct -----
-parquet_go_root struct{
-  name string
-  age int32
-  id int64
-  weight float32
-  sex bool
-  day int32
-}
------ Json schema -----
 {
   "Tag": "name=parquet_go_root, repetitiontype=REQUIRED",
   "Fields": [
@@ -67,5 +62,37 @@ parquet_go_root struct{
 ### Show records
 ```bash
 #show first 2 records of a.parquet
-./parquet-tools -cmd cat -count 2 -file a.parquet 
+bash$ ./parquet-tools -cmd cat -count 2 -file a.parquet 
+```
+
+### Show metadata of an S3 object
+```bash
+# data is from https://pro.dp.la/developers/bulk-download
+bash$ ./parquet-tools -cmd metadata -file s3://dpla-provider-export/2021/03/all.parquet/part-00000-56ba8f11-cb30-4bc3-8f6d-dd26c0dd1f06-c000.snappy.parquet
+{
+  "RowGroups": [
+    {
+      "Columns": [
+        {
+          "Name": "Doc.Uri",
+          "ValueCount": 385959,
+          "NullCount": 0,
+          "UncompressedSize": 22774880,
+          "CompressedSize": 12971526
+        },
+        {
+          "Name": "Doc.Id",
+          "ValueCount": 385959,
+          "NullCount": 0,
+          "UncompressedSize": 13895977,
+          "CompressedSize": 12576719
+        },
+        {
+          "Name": "Doc.DataProvider.List.Element",
+          "ValueCount": 385959,
+          "NullCount": 0,
+          "UncompressedSize": 355531,
+          "CompressedSize": 258478
+        },
+...
 ```

--- a/tool/parquet-tools/metadatatool/metadatatool.go
+++ b/tool/parquet-tools/metadatatool/metadatatool.go
@@ -1,0 +1,44 @@
+package metadatatool
+
+import (
+	"strings"
+
+	"github.com/xitongsys/parquet-go/reader"
+)
+
+type ColumnMeta struct {
+	Name             string
+	ValueCount       int64
+	DistinctCount    *int64 `json:",omitempty"`
+	NullCount        *int64 `json:",omitempty"`
+	UncompressedSize int64
+	CompressedSize   int64
+}
+
+type RowGroupMeta struct {
+	Columns []ColumnMeta
+}
+
+type Metadata struct {
+	RowGroups []RowGroupMeta
+}
+
+func GetMetadata(pr *reader.ParquetReader) (Metadata, error) {
+	metadata := Metadata{
+		RowGroups: make([]RowGroupMeta, len(pr.Footer.RowGroups)),
+	}
+	for i, rowGroup := range pr.Footer.RowGroups {
+		for _, col := range rowGroup.Columns {
+			colMeta := ColumnMeta{
+				Name:             strings.Join(col.MetaData.PathInSchema, "."),
+				ValueCount:       col.MetaData.NumValues,
+				DistinctCount:    col.MetaData.Statistics.DistinctCount,
+				NullCount:        col.MetaData.Statistics.NullCount,
+				UncompressedSize: col.MetaData.TotalUncompressedSize,
+				CompressedSize:   col.MetaData.TotalCompressedSize,
+			}
+			metadata.RowGroups[i].Columns = append(metadata.RowGroups[i].Columns, colMeta)
+		}
+	}
+	return metadata, nil
+}

--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -18,6 +18,7 @@ import (
 	"github.com/xitongsys/parquet-go-source/s3"
 	"github.com/xitongsys/parquet-go/reader"
 	"github.com/xitongsys/parquet-go/source"
+	"github.com/xitongsys/parquet-go/tool/parquet-tools/metadatatool"
 	"github.com/xitongsys/parquet-go/tool/parquet-tools/schematool"
 	"github.com/xitongsys/parquet-go/tool/parquet-tools/sizetool"
 )
@@ -129,6 +130,14 @@ func main() {
 
 			totCnt += cnt
 		}
+	case "metadata":
+		metadata, err := metadatatool.GetMetadata(pr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't to get metadata: %s\n", err)
+			os.Exit(1)
+		}
+		buf, _ := json.MarshalIndent(metadata, "", "  ")
+		fmt.Println(string(buf))
 
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %s\n", *cmd)


### PR DESCRIPTION
This PR added `metadata` command to parquet-tools to show metadata of each row group, it also updated README file to reflect most recent version.