### PR TITLE
minor fix to compress/lz4.go

### DIFF
--- a/compress/lz4.go
+++ b/compress/lz4.go
@@ -1,14 +1,15 @@
 // +build !no_lz4
+
 package compress
 
 import (
 	"bytes"
-	"github.com/pierrec/lz4/v4"
-	"github.com/xitongsys/parquet-go/parquet"
 	"io/ioutil"
 	"sync"
-)
 
+	"github.com/pierrec/lz4/v4"
+	"github.com/xitongsys/parquet-go/parquet"
+)
 
 func init() {
 	lz4WriterPool := sync.Pool{


### PR DESCRIPTION
I got follow error without this patch:

> compress/lz4.go:1: +build comment must appear before package clause and be followed by a blank line

the file got reformatted a bit as well.

EDIT if go version matters:
```
$ go version
go version go1.16.4 darwin/arm64
```