### PR TITLE
schema: Omit null fields from being encoded to JSON

### DIFF
--- a/compress/lz4.go
+++ b/compress/lz4.go
@@ -1,4 +1,5 @@
 // +build !no_lz4
+
 package compress
 
 import (

--- a/schema/json.go
+++ b/schema/json.go
@@ -10,8 +10,8 @@ import (
 )
 
 type JSONSchemaItemType struct {
-	Tag    string
-	Fields []*JSONSchemaItemType
+	Tag    string                `json:"Tag"`
+	Fields []*JSONSchemaItemType `json:"Fields,omitempty"`
 }
 
 func NewJSONSchemaItem() *JSONSchemaItemType {


### PR DESCRIPTION
This patch disables encoding the `Fields` field of `JSONSchemaItemType` if its `nil`. 

I was using tool/parquet-tools to get the schema from a parquet file generated using this library and got a bunch of `null` values for `Fields` in the output JSON schema. This PR gets rid of those `null` values from the JSON schema.
