### PR TITLE
fix for byte array as decimal with negative value

### DIFF
--- a/example/type.go
+++ b/example/type.go
@@ -129,6 +129,8 @@ func main() {
 		if err = pr.Read(&tps); err != nil {
 			log.Println("Read error", err)
 		}
+		tps[0].Decimal3 = types.DECIMAL_BYTE_ARRAY_ToString([]byte(tps[0].Decimal3), 10, 2)
+		tps[0].Decimal4 = types.DECIMAL_BYTE_ARRAY_ToString([]byte(tps[0].Decimal4), 20, 2)
 		log.Println(tps)
 	}
 	pr.ReadStop()

--- a/types/converter.go
+++ b/types/converter.go
@@ -122,6 +122,14 @@ func DECIMAL_INT_ToString(dec int64, precision int, scale int) string {
 }
 
 func DECIMAL_BYTE_ARRAY_ToString(dec []byte, precision int, scale int) string {
+	sign := ""
+	if dec[0] > 0x7f {
+		sign = "-"
+		for i := range dec {
+			dec[i] = dec[i] ^ 0xff
+		}
+		dec[len(dec)-1] += 1
+	}
 	a := new(big.Int)
 	a.SetBytes(dec)
 	sa := a.Text(10)
@@ -130,5 +138,5 @@ func DECIMAL_BYTE_ARRAY_ToString(dec []byte, precision int, scale int) string {
 		ln := len(sa)
 		sa = sa[:ln-scale] + "." + sa[ln-scale:]
 	}
-	return sa
+	return sign + sa
 }

--- a/types/converter.go
+++ b/types/converter.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -136,6 +137,10 @@ func DECIMAL_BYTE_ARRAY_ToString(dec []byte, precision int, scale int) string {
 
 	if scale > 0 {
 		ln := len(sa)
+		if ln < scale+1 {
+			sa = strings.Repeat("0", scale+1-ln) + sa
+			ln = scale + 1
+		}
 		sa = sa[:ln-scale] + "." + sa[ln-scale:]
 	}
 	return sign + sa

--- a/types/converter_test.go
+++ b/types/converter_test.go
@@ -42,4 +42,22 @@ func TestDECIMAL(t *testing.T) {
 	if sa4 != "-123.456" {
 		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a4, sa4)
 	}
+
+	a5, _ := StrToParquetType("0.000", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 9, 3)
+	sa5 := DECIMAL_BYTE_ARRAY_ToString([]byte(a5.(string)), 9, 3)
+	if sa5 != "0.000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a5, sa5)
+	}
+
+	a6, _ := StrToParquetType("-0.01", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 6, 2)
+	sa6 := DECIMAL_BYTE_ARRAY_ToString([]byte(a6.(string)), 6, 2)
+	if sa6 != "-0.01" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a6, sa6)
+	}
+
+	a7, _ := StrToParquetType("0.1234", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa7 := DECIMAL_BYTE_ARRAY_ToString([]byte(a7.(string)), 8, 4)
+	if sa7 != "0.1234" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a7, sa7)
+	}
 }

--- a/types/converter_test.go
+++ b/types/converter_test.go
@@ -37,4 +37,9 @@ func TestDECIMAL(t *testing.T) {
 		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a3, sa3)
 	}
 
+	a4, _ := StrToParquetType("-123.456", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 9, 3)
+	sa4 := DECIMAL_BYTE_ARRAY_ToString([]byte(a4.(string)), 9, 3)
+	if sa4 != "-123.456" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a4, sa4)
+	}
 }


### PR DESCRIPTION
It seems `DECIMAL_BYTE_ARRAY_ToString` has a bug when dealing with negative decimal value, there may be a better way to address this, but this approach works for me.

EDIT one more commit to fix values between -1 and 1.