### PR TITLE
Don't allocate buffers for entire page

### DIFF
--- a/layout/rowgroup.go
+++ b/layout/rowgroup.go
@@ -90,8 +90,7 @@ func ReadRowGroup(rowGroupHeader *parquet.RowGroup, PFile source.ParquetFile, sc
 				} else {
 					PFile, _ = PFile.Open("")
 				}
-				size := columnChunks[i].MetaData.GetTotalCompressedSize()
-				thriftReader := source.ConvertToThriftReader(PFile, offset, size)
+				thriftReader := source.ConvertToThriftReader(PFile, offset)
 				chunk, _ := ReadChunk(thriftReader, schemaHandler, columnChunks[i])
 				chunksList[index] = append(chunksList[index], chunk)
 				PFile.Close()

--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -92,12 +92,11 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 		offset = *columnChunks[i].MetaData.DictionaryPageOffset
 	}
 
-	size := columnChunks[i].MetaData.GetTotalCompressedSize()
 	if cbt.ThriftReader != nil {
 		cbt.ThriftReader.Close()
 	}
 
-	cbt.ThriftReader = source.ConvertToThriftReader(cbt.PFile, offset, size)
+	cbt.ThriftReader = source.ConvertToThriftReader(cbt.PFile, offset)
 	cbt.ChunkReadValues = 0
 	cbt.DictPage = nil
 	return nil

--- a/source/source.go
+++ b/source/source.go
@@ -15,10 +15,12 @@ type ParquetFile interface {
 	Create(name string) (ParquetFile, error)
 }
 
+const bufferSize = 4096
+
 //Convert a file reater to Thrift reader
-func ConvertToThriftReader(file ParquetFile, offset int64, size int64) *thrift.TBufferedTransport {
+func ConvertToThriftReader(file ParquetFile, offset int64) *thrift.TBufferedTransport {
 	file.Seek(offset, 0)
 	thriftReader := thrift.NewStreamTransportR(file)
-	bufferReader := thrift.NewTBufferedTransport(thriftReader, int(size))
+	bufferReader := thrift.NewTBufferedTransport(thriftReader, bufferSize)
 	return bufferReader
 }


### PR DESCRIPTION
On large parquet files these allocated hundreds of MB and caused OOM on
systems with limited memory (1GB). Decreasing the buffer size doesn't
have a huge impact on performance and lets us parse larger files