### PR TITLE
Appropriately size buffer when reading footer

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -133,7 +133,6 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -143,7 +143,9 @@ func (pr *ParquetReader) ReadFooter() error {
 	}
 	pr.Footer = parquet.NewFileMetaData()
 	pf := thrift.NewTCompactProtocolFactory()
-	protocol := pf.GetProtocol(thrift.NewStreamTransportR(pr.PFile))
+	thriftReader := thrift.NewStreamTransportR(pr.PFile)
+	bufferReader := thrift.NewTBufferedTransport(thriftReader, int(size))
+	protocol := pf.GetProtocol(bufferReader)
 	return pr.Footer.Read(context.TODO(), protocol)
 }
 


### PR DESCRIPTION
Using the default buffer size (4K) when reading the footer causes
repeated small reads rather than one read of the correct size. This is
especially bad when using a datasource like S3 that charges a cost
per request regardless of the size of data returned.

Ideally ReadFooter could estimate the footer size and attempt to read
the footer size and the footer in a single read operation, only making a
second request if it under-estimated, but doing that correctly is much
harder.