### PR TITLE
Do not panic when ReadRows() on parquet file with zero record

### DIFF
--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -230,6 +230,10 @@ func (cbt *ColumnBufferType) SkipRows(num int64) int64 {
 }
 
 func (cbt *ColumnBufferType) ReadRows(num int64) (*layout.Table, int64) {
+	if cbt.Footer.NumRows == 0 {
+		return &layout.Table{}, 0
+	}
+
 	var err error
 
 	for cbt.DataTableNumRows < num && err == nil {


### PR DESCRIPTION
This is to address https://github.com/xitongsys/parquet-go/issues/438, with this commit:
```
$ go run ./tool/parquet-tools/ -cmd cat --file empty.parquet
[]
$ go run ./tool/parquet-tools/ -cmd size --file empty.parquet
empty.parquet: 0 bytes
$ go run ./tool/parquet-tools/ -cmd rowcount --file empty.parquet
0
```