### PR TITLE
add length to INTERVAL schema

### DIFF
--- a/tool/parquet-tools/schematool/schematool.go
+++ b/tool/parquet-tools/schematool/schematool.go
@@ -146,6 +146,10 @@ func (n *Node) OutputJsonSchema() string {
 				res += fmt.Sprintf(tagStr, name, pTStr, cTStr, scale, precision, rTStr) + "}"
 			}
 
+		} else if cT != nil && *cT == parquet.ConvertedType_INTERVAL {
+			tagStr := "\"name=%s, type=%s, convertedtype=%s, length=12, repetitiontype=%s\""
+			res += fmt.Sprintf(tagStr, name, pTStr, cTStr, rTStr) + "}"
+
 		} else {
 			if cT != nil {
 				tagStr := "\"name=%s, type=%s, convertedtype=%s, repetitiontype=%s\""
@@ -244,6 +248,9 @@ func (n *Node) getStructTags() string {
 			tagStr := "`parquet:\"name=%s, type=%s, convertedtype=%s, scale=%d, precision=%d, repetitiontype=%s\"`"
 			tags = fmt.Sprintf(tagStr, n.SE.Name, pTStr, n.SE.Type, scale, precision, rTStr)
 		}
+	} else if cT != nil && *cT == parquet.ConvertedType_INTERVAL {
+		tagStr := "`parquet:\"name=%s, type=%s, convertedtype=%s, length=12, repetitiontype=%s\"`"
+		tags = fmt.Sprintf(tagStr, n.SE.Name, pTStr, cTStr, rTStr)
 	}
 
 	return tags


### PR DESCRIPTION
tools' `schema` output lacks of `length` for INTERVAL type, if one uses the output to process data, INTERVAL type will be zero length.

Current output:
```
$ go run ./tool/parquet-tools/ -cmd schema -file example/type.parquet --schema-format go -tag| grep -i interval
  Interval string `parquet:"name=Interval, type=INTERVAL, repetitiontype=REQUIRED"`
$ go run ./tool/parquet-tools/ -cmd schema -file example/type.parquet | grep -i interval
      "Tag": "name=Interval, type=FIXED_LEN_BYTE_ARRAY, convertedtype=INTERVAL, repetitiontype=REQUIRED"
```

This PR adds `length=12` to the schema, also fix go struct output:
```
$ go run ./tool/parquet-tools/ -cmd schema -file example/type.parquet --schema-format go -tag| grep -i interval
  Interval string `parquet:"name=Interval, type=FIXED_LEN_BYTE_ARRAY, convertedtype=INTERVAL, length=12, repetitiontype=REQUIRED"`
$ go run ./tool/parquet-tools/ -cmd schema -file example/type.parquet | grep -i interval
      "Tag": "name=Interval, type=FIXED_LEN_BYTE_ARRAY, convertedtype=INTERVAL, length=12, repetitiontype=REQUIRED"
```