### PR TITLE
Split ParquetFile into R/W interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,19 @@ There are three repetition types in Parquet: REQUIRED, OPTIONAL, REPEATED.
 
 ## ParquetFile
 
-Read/Write a parquet file need a ParquetFile interface implemented
+Reading or writing a parquet file requires an implementation of the ParquetFileR or ParquetFileW interface.
 
 ```golang
-type ParquetFile interface {
+type ParquetFileR interface {
 	io.Seeker
 	io.Reader
+	io.Closer
+	Open(name string) (ParquetReadFile, error)
+}
+
+type ParquetFileW interface {
 	io.Writer
 	io.Closer
-	Open(name string) (ParquetFile, error)
-	Create(name string) (ParquetFile, error)
 }
 ```
 
@@ -362,11 +365,11 @@ var jsonSchema string = `
 Marshal/Unmarshal is the most time consuming process in writing/reading. To improve the performance, parquet-go can use multiple goroutines to marshal/unmarshal the objects. You can set the concurrent number parameter `np` in the Read/Write initial functions.
 
 ```golang
-func NewParquetReader(pFile ParquetFile.ParquetFile, obj interface{}, np int64) (*ParquetReader, error)
-func NewParquetWriter(pFile ParquetFile.ParquetFile, obj interface{}, np int64) (*ParquetWriter, error)
-func NewJSONWriter(jsonSchema string, pfile ParquetFile.ParquetFile, np int64) (*JSONWriter, error)
-func NewCSVWriter(md []string, pfile ParquetFile.ParquetFile, np int64) (*CSVWriter, error)
-func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFile, np int64) (*ArrowWriter error)
+func NewParquetReader(pFile source.ParquetFileR, obj interface{}, np int64) (*ParquetReader, error)
+func NewParquetWriter(pFile source.ParquetFileW, obj interface{}, np int64) (*ParquetWriter, error)
+func NewJSONWriter(jsonSchema string, pfile source.ParquetFileW, np int64) (*JSONWriter, error)
+func NewCSVWriter(md []string, pfile source.ParquetFileW, np int64) (*CSVWriter, error)
+func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileW, np int64) (*ArrowWriter error)
 ```
 
 ## Examples

--- a/layout/rowgroup.go
+++ b/layout/rowgroup.go
@@ -42,7 +42,7 @@ func (rowGroup *RowGroup) RowGroupToTableMap() *map[string]*Table {
 }
 
 //Read one RowGroup from parquet file (Deprecated)
-func ReadRowGroup(rowGroupHeader *parquet.RowGroup, PFile source.ParquetFile, schemaHandler *schema.SchemaHandler, NP int64) (*RowGroup, error) {
+func ReadRowGroup(rowGroupHeader *parquet.RowGroup, PFile source.ParquetFileR, schemaHandler *schema.SchemaHandler, NP int64) (*RowGroup, error) {
 	var err error
 	rowGroup := new(RowGroup)
 	rowGroup.RowGroupHeader = rowGroupHeader

--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ColumnBufferType struct {
-	PFile        source.ParquetFile
+	PFile        source.ParquetFileR
 	ThriftReader *thrift.TBufferedTransport
 
 	Footer        *parquet.FileMetaData
@@ -31,7 +31,7 @@ type ColumnBufferType struct {
 	DataTableNumRows int64
 }
 
-func NewColumnBuffer(pFile source.ParquetFile, footer *parquet.FileMetaData, schemaHandler *schema.SchemaHandler, pathStr string) (*ColumnBufferType, error) {
+func NewColumnBuffer(pFile source.ParquetFileR, footer *parquet.FileMetaData, schemaHandler *schema.SchemaHandler, pathStr string) (*ColumnBufferType, error) {
 	newPFile, err := pFile.Open("")
 	if err != nil {
 		return nil, err

--- a/reader/columnreader.go
+++ b/reader/columnreader.go
@@ -8,7 +8,8 @@ import (
 )
 
 // NewParquetColumnReader creates a parquet column reader
-func NewParquetColumnReader(pFile source.ParquetFile, np int64) (*ParquetReader, error) {
+func NewParquetColumnReader(pFile source.ParquetFileR, np int64) (*ParquetReader,
+	error) {
 	res := new(ParquetReader)
 	res.NP = np
 	res.PFile = pFile

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -21,7 +21,7 @@ type ParquetReader struct {
 	SchemaHandler *schema.SchemaHandler
 	NP            int64 //parallel number
 	Footer        *parquet.FileMetaData
-	PFile         source.ParquetFile
+	PFile         source.ParquetFileR
 
 	ColumnBuffers map[string]*ColumnBufferType
 
@@ -31,7 +31,7 @@ type ParquetReader struct {
 }
 
 //Create a parquet reader: obj is a object with schema tags or a JSON schema string
-func NewParquetReader(pFile source.ParquetFile, obj interface{}, np int64) (*ParquetReader, error) {
+func NewParquetReader(pFile source.ParquetFileR, obj interface{}, np int64) (*ParquetReader, error) {
 	var err error
 	res := new(ParquetReader)
 	res.NP = np

--- a/source/source.go
+++ b/source/source.go
@@ -6,19 +6,28 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
-type ParquetFile interface {
+type ParquetFileR interface {
 	io.Seeker
 	io.Reader
+	io.Closer
+	Open(name string) (ParquetFileR, error)
+}
+
+type ParquetFileW interface {
 	io.Writer
 	io.Closer
-	Open(name string) (ParquetFile, error)
+}
+
+type ParquetFile interface {
+	ParquetFileR
+	ParquetFileW
 	Create(name string) (ParquetFile, error)
 }
 
 const bufferSize = 4096
 
 //Convert a file reater to Thrift reader
-func ConvertToThriftReader(file ParquetFile, offset int64) *thrift.TBufferedTransport {
+func ConvertToThriftReader(file ParquetFileR, offset int64) *thrift.TBufferedTransport {
 	file.Seek(offset, 0)
 	thriftReader := thrift.NewStreamTransportR(file)
 	bufferReader := thrift.NewTBufferedTransport(thriftReader, bufferSize)

--- a/tool/parquet-tools/parquet-tools.go
+++ b/tool/parquet-tools/parquet-tools.go
@@ -56,7 +56,7 @@ func main() {
 		uri.Scheme = "file"
 	}
 
-	var fr source.ParquetFile
+	var fr source.ParquetFileR
 	switch uri.Scheme {
 	case "s3":
 		// determine S3 bucket's region

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -29,7 +29,7 @@ type ArrowWriter struct {
 //arrow schema, parquet file writer which contains the parquet file in
 //which we will write the record along with the number of parallel threads
 //which will write in the file.
-func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFile,
+func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileW,
 	np int64) (*ArrowWriter, error) {
 	var err error
 	res := new(ArrowWriter)

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -23,7 +23,7 @@ func NewCSVWriterFromWriter(md []string, w io.Writer, np int64) (*CSVWriter, err
 }
 
 //Create CSV writer
-func NewCSVWriter(md []string, pfile source.ParquetFile, np int64) (*CSVWriter, error) {
+func NewCSVWriter(md []string, pfile source.ParquetFileW, np int64) (*CSVWriter, error) {
 	var err error
 	res := new(CSVWriter)
 	res.SchemaHandler, err = schema.NewSchemaHandlerFromMetadata(md)

--- a/writer/json.go
+++ b/writer/json.go
@@ -21,7 +21,7 @@ func NewJSONWriterFromWriter(jsonSchema string, w io.Writer, np int64) (*JSONWri
 }
 
 //Create JSON writer
-func NewJSONWriter(jsonSchema string, pfile source.ParquetFile, np int64) (*JSONWriter, error) {
+func NewJSONWriter(jsonSchema string, pfile source.ParquetFileW, np int64) (*JSONWriter, error) {
 	var err error
 	res := new(JSONWriter)
 	res.SchemaHandler, err = schema.NewSchemaHandlerFromJSON(jsonSchema)

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -23,7 +23,7 @@ type ParquetWriter struct {
 	SchemaHandler *schema.SchemaHandler
 	NP            int64 //parallel number
 	Footer        *parquet.FileMetaData
-	PFile         source.ParquetFile
+	PFile         source.ParquetFileW
 
 	PageSize        int64
 	RowGroupSize    int64
@@ -53,7 +53,7 @@ func NewParquetWriterFromWriter(w io.Writer, obj interface{}, np int64) (*Parque
 }
 
 //Create a parquet handler. Obj is a object with tags or JSON schema string.
-func NewParquetWriter(pFile source.ParquetFile, obj interface{}, np int64) (*ParquetWriter, error) {
+func NewParquetWriter(pFile source.ParquetFileW, obj interface{}, np int64) (*ParquetWriter, error) {
 	var err error
 
 	res := new(ParquetWriter)


### PR DESCRIPTION
Create ParquetFileR and ParquetFileW interfaces that represent files
that can be read from or written to respectively. Replace usages of the
ParquetFile interface with the relevant R/W interface. An equivalent of
ParquetFile is left in place for backward compatibility.

Having a shared interface for read and written files adds little to this
library, since no file ever needs to be both read and written to, and
they have little overlap in their interfaces.

The combined interface complicates the contract. It must define
interactions between read methods (e.g. Seek) and write methods (e.g.
Write) even though such interactions are never used. In theory,
existing implementations should define the same interactions, but they
probably don't.

The combined interface also complicates writing new implementations of
the interfaces. A read-only datasource can't "fully" implement the
ParquetFile interface. A read/write data-source must care about the
interactions described above. Splitting the interface resolves these
issues. Users can write types that implement only the behavior that
their datasource can support. They can write separate types to implement
read and write behavior for the same datasource, to eliminate the
possibility of interactions between read/write methods.