### PR TITLE
Fix the Arrow integration to support Nullability

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -12,7 +12,6 @@ import (
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/xitongsys/parquet-go/parquet"
-	"github.com/xitongsys/parquet-go/types"
 )
 
 // `parquet:"name=Name, type=FIXED_LEN_BYTE_ARRAY, length=12"`
@@ -1020,329 +1019,225 @@ func TransposeTable(table [][]interface{}) [][]interface{} {
 	return transposedTable
 }
 
-// ArrowColToParquetCol creates column with native parquet values from column
-// with arrow values.
+// ArrowColToParquetCol creates column with native go values from column
+// with arrow values according to the rules described in the Type section in
+// the project's README.md file.
 //
-// If a single record is not valid by the arrow definitions we assign it
-// default value which we chose.
-func ArrowColToParquetCol(field arrow.Field, col array.Interface, len int,
-	el *parquet.SchemaElement) ([]interface{}, error) {
-	var err error
-	recs := make([]interface{}, len)
+// If `col` contains Null value but `field` is not marked as Nullable this
+// results in an error.
+func ArrowColToParquetCol(field arrow.Field, col array.Interface) (
+	[]interface{}, error) {
+	recs := make([]interface{}, col.Len())
 	switch field.Type.(type) {
 	case *arrow.Int8Type:
 		arr := col.(*array.Int8)
-		var rec int8
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Int16Type:
 		arr := col.(*array.Int16)
-		var rec int16
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Int32Type:
 		arr := col.(*array.Int32)
-		var rec int32
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.Int64Type:
 		arr := col.(*array.Int64)
-		var rec int64
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.Uint8Type:
 		arr := col.(*array.Uint8)
-		var rec uint8
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Uint16Type:
 		arr := col.(*array.Uint16)
-		var rec uint16
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Uint32Type:
 		arr := col.(*array.Uint32)
-		var rec int32
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = int32(arr.Value(i))
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Uint64Type:
 		arr := col.(*array.Uint64)
-		var rec int64
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = int64(arr.Value(i))
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = int64(arr.Value(i))
 			}
 		}
 	case *arrow.Float32Type:
 		arr := col.(*array.Float32)
-		var rec float32
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.Float64Type:
 		arr := col.(*array.Float64)
-		var rec float64
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.Date32Type:
 		arr := col.(*array.Date32)
-		var rec arrow.Date32
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.Date64Type:
 		arr := col.(*array.Date64)
-		var rec arrow.Date64
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.BinaryType:
 		arr := col.(*array.Binary)
-		var rec []byte
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = []byte("")
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = string(arr.Value(i))
 			}
 		}
 	case *arrow.StringType:
 		arr := col.(*array.String)
-		var rec string
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = ""
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.BooleanType:
 		arr := col.(*array.Boolean)
-		var rec bool
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = false
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = arr.Value(i)
 			}
 		}
 	case *arrow.Time32Type:
 		arr := col.(*array.Time32)
-		var rec arrow.Time32
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = int32(arr.Value(i))
 			}
 		}
 	case *arrow.TimestampType:
 		arr := col.(*array.Timestamp)
-		var rec arrow.Timestamp
 		for i := 0; i < arr.Len(); i++ {
-			if arr.IsValid(i) {
-				rec = arr.Value(i)
+			if arr.IsNull(i) {
+				if !field.Nullable {
+					return nil, nonNullableFieldContainsNullError(field, i)
+				}
+				recs[i] = nil
 			} else {
-				rec = 0
-			}
-			recs[i], err = types.StrToParquetType(fmt.Sprintf("%v", rec),
-				el.Type,
-				el.ConvertedType,
-				int(el.GetTypeLength()),
-				int(el.GetScale()))
-			if err != nil {
-				return nil, err
+				recs[i] = int64(arr.Value(i))
 			}
 		}
 	}
 	return recs, nil
+}
+
+func nonNullableFieldContainsNullError(field arrow.Field, idx int) error {
+	return fmt.Errorf("field with name '%s' is marked non-nullable but its "+
+		"column array contains Null value at index %d", field.Name, idx)
 }

--- a/example/arrow_to_parquet.go
+++ b/example/arrow_to_parquet.go
@@ -26,6 +26,8 @@ func main() {
 			{Name: "float64", Type: arrow.PrimitiveTypes.Float64},
 			{Name: "str", Type: arrow.BinaryTypes.String},
 			{Name: "ts_ms", Type: arrow.FixedWidthTypes.Timestamp_ms},
+			{Name: "nullable-int32", Type: arrow.PrimitiveTypes.Int32,
+				Nullable: true},
 		},
 		nil,
 	)
@@ -48,6 +50,12 @@ func main() {
 		case 3:
 			n := arrow.Timestamp(time.Now().UnixMilli())
 			b.Field(idx).(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{n, n, n}, nil)
+		case 4:
+			colBuilder := b.Field(idx).(*array.Int32Builder)
+			colBuilder.Append(1)
+			colBuilder.AppendNull()
+			colBuilder.Append(2)
+			colBuilder.AppendNull()
 		}
 	}
 	rec := b.NewRecord()

--- a/marshal/arrow.go
+++ b/marshal/arrow.go
@@ -12,33 +12,47 @@ import (
 // column by column since the wrapper ParquetWriter uses the number of rows
 // to execute intermediate flush depending on the size of the objects,
 // determined by row, which are currently written.
-func MarshalArrow(recs []interface{}, schemaHandler *schema.SchemaHandler) (
-	tb *map[string]*layout.Table, err error) {
+func MarshalArrow(records []interface{}, schemaHandler *schema.SchemaHandler) (*map[string]*layout.Table, error) {
 	res := make(map[string]*layout.Table)
-	if ln := len(recs); ln <= 0 {
+	if ln := len(records); ln <= 0 {
 		return &res, nil
 	}
-
-	for i := 0; i < len(recs[0].([]interface{})); i++ {
-		pathStr := schemaHandler.GetRootInName() + common.PAR_GO_PATH_DELIMITER +
-			schemaHandler.Infos[i+1].InName
+	for i := 0; i < len(records[0].([]interface{})); i++ {
+		pathStr := schemaHandler.GetRootInName() + common.PAR_GO_PATH_DELIMITER + schemaHandler.Infos[i+1].InName
 		table := layout.NewEmptyTable()
 		res[pathStr] = table
 		table.Path = common.StrToPath(pathStr)
-		table.MaxDefinitionLevel = 0
-		table.MaxRepetitionLevel = 0
-		table.RepetitionType = parquet.FieldRepetitionType_REQUIRED
-		table.Schema =
-			schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
-		table.Info = schemaHandler.Infos[i+1]
-		// Pre-allocate these arrays for efficiency
-		table.Values = make([]interface{}, 0, len(recs))
-		table.RepetitionLevels = make([]int32, len(recs))
-		table.DefinitionLevels = make([]int32, len(recs))
 
-		for j := 0; j < len(recs); j++ {
-			rec := recs[j].([]interface{})[i]
+		schema := schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
+		isOptional := true
+		if *schema.RepetitionType != parquet.FieldRepetitionType_OPTIONAL {
+			isOptional = false
+		}
+
+		if isOptional {
+			table.MaxDefinitionLevel = 1
+		} else {
+			table.MaxDefinitionLevel = 0
+		}
+		table.MaxRepetitionLevel = 0
+		table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
+		table.RepetitionType = *table.Schema.RepetitionType
+		table.Info = schemaHandler.Infos[i+1]
+		// Pre-allocate these arrays for efficiency.
+		table.Values = make([]interface{}, 0, len(records))
+		table.RepetitionLevels = make([]int32, 0, len(records))
+		table.DefinitionLevels = make([]int32, 0, len(records))
+
+		for j := 0; j < len(records); j++ {
+			rec := records[j].([]interface{})[i]
 			table.Values = append(table.Values, rec)
+
+			table.RepetitionLevels = append(table.RepetitionLevels, 0)
+			if rec == nil || !isOptional {
+				table.DefinitionLevels = append(table.DefinitionLevels, 0)
+			} else {
+				table.DefinitionLevels = append(table.DefinitionLevels, 1)
+			}
 		}
 	}
 	return &res, nil

--- a/schema/arrow.go
+++ b/schema/arrow.go
@@ -11,8 +11,9 @@ import (
 // Schema metadata used to parse the native and converted types and
 // creating the schema definitions
 const (
-	convertedMetaDataTemplate = "name=%s, type=%s, convertedtype=%s"
-	primitiveMetaDataTemplate = "name=%s, type=%s"
+	convertedMetaDataTemplate = "name=%s, type=%s, convertedtype=%s, " +
+		"repetitiontype=%s"
+	primitiveMetaDataTemplate = "name=%s, type=%s, repetitiontype=%s"
 	rootNodeName              = "Parquet45go45root"
 )
 
@@ -25,63 +26,76 @@ func ConvertArrowToParquetSchema(schema *arrow.Schema) ([]string, error) {
 	metaData := make([]string, len(schema.Fields()))
 	var err error
 	for k, v := range schema.Fields() {
+		repetitionType := parquet.FieldRepetitionType_REQUIRED
+		if v.Nullable {
+			repetitionType = parquet.FieldRepetitionType_OPTIONAL
+		}
 		switch fieldType := v.Type; fieldType.Name() {
 		case arrow.PrimitiveTypes.Int8.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_INT_8)
+				v.Name, parquet.Type_INT32, parquet.ConvertedType_INT_8,
+				repetitionType)
 		case arrow.PrimitiveTypes.Int16.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_INT_16)
+				v.Name, parquet.Type_INT32, parquet.ConvertedType_INT_16,
+				repetitionType)
 		case arrow.PrimitiveTypes.Int32.Name():
-			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_INT_32)
+			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate,
+				v.Name, parquet.Type_INT32, repetitionType)
 		case arrow.PrimitiveTypes.Int64.Name():
-			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT64, parquet.ConvertedType_INT_64)
+			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate,
+				v.Name, parquet.Type_INT64, repetitionType)
 		case arrow.PrimitiveTypes.Uint8.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_8)
+				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_8,
+				repetitionType)
 		case arrow.PrimitiveTypes.Uint16.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_16)
+				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_16,
+				repetitionType)
 		case arrow.PrimitiveTypes.Uint32.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_32)
+				v.Name, parquet.Type_INT32, parquet.ConvertedType_UINT_32,
+				repetitionType)
 		case arrow.PrimitiveTypes.Uint64.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate,
-				v.Name, parquet.Type_INT64, parquet.ConvertedType_UINT_64)
+				v.Name, parquet.Type_INT64, parquet.ConvertedType_UINT_64,
+				repetitionType)
 		case arrow.PrimitiveTypes.Float32.Name():
 			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate, v.Name,
-				parquet.Type_FLOAT)
+				parquet.Type_FLOAT, repetitionType)
 		case arrow.PrimitiveTypes.Float64.Name():
 			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate, v.Name,
-				parquet.Type_DOUBLE)
+				parquet.Type_DOUBLE, repetitionType)
 		case arrow.PrimitiveTypes.Date32.Name(),
 			arrow.PrimitiveTypes.Date64.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate, v.Name,
-				parquet.Type_INT32, parquet.ConvertedType_DATE)
+				parquet.Type_INT32, parquet.ConvertedType_DATE, repetitionType)
 		case arrow.FixedWidthTypes.Date32.Name(), arrow.FixedWidthTypes.Date64.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate, v.Name,
-				parquet.Type_INT32, parquet.ConvertedType_DATE)
+				parquet.Type_INT32, parquet.ConvertedType_DATE, repetitionType)
 		case arrow.BinaryTypes.Binary.Name():
 			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate, v.Name,
-				parquet.Type_BYTE_ARRAY)
+				parquet.Type_BYTE_ARRAY, repetitionType)
 		case arrow.BinaryTypes.String.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate, v.Name,
-				parquet.Type_BYTE_ARRAY, parquet.ConvertedType_UTF8)
+				parquet.Type_BYTE_ARRAY, parquet.ConvertedType_UTF8,
+				repetitionType)
 		case arrow.FixedWidthTypes.Boolean.Name():
 			metaData[k] = fmt.Sprintf(primitiveMetaDataTemplate, v.Name,
-				parquet.Type_BOOLEAN)
+				parquet.Type_BOOLEAN, repetitionType)
 		case arrow.FixedWidthTypes.Time32ms.Name():
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate, v.Name,
-				parquet.Type_INT32, parquet.ConvertedType_TIME_MILLIS)
+				parquet.Type_INT32, parquet.ConvertedType_TIME_MILLIS,
+				repetitionType)
 		case arrow.FixedWidthTypes.Timestamp_ms.Name():
 			tsType := fieldType.(*arrow.TimestampType)
 			if tsType.Unit != arrow.Millisecond {
 				return nil, fmt.Errorf("Unsupported arrow format: %s", tsType.String())
 			}
 			metaData[k] = fmt.Sprintf(convertedMetaDataTemplate, v.Name,
-				parquet.Type_INT64, parquet.ConvertedType_TIMESTAMP_MILLIS)
+				parquet.Type_INT64, parquet.ConvertedType_TIMESTAMP_MILLIS,
+				repetitionType)
 		default:
 			return nil,
 				fmt.Errorf("Unsupported arrow format: %s", fieldType.Name())

--- a/schema/arrow_test.go
+++ b/schema/arrow_test.go
@@ -29,20 +29,72 @@ func TestTypeConversion(t *testing.T) {
 				{Name: "f1-f62", Type: arrow.PrimitiveTypes.Float64},
 				{Name: "f1-d32", Type: arrow.PrimitiveTypes.Date32},
 				{Name: "f1-d64", Type: arrow.PrimitiveTypes.Date64},
+				{Name: "null-i8", Type: arrow.PrimitiveTypes.Int8,
+					Nullable: true},
+				{Name: "null-i16", Type: arrow.PrimitiveTypes.Int16,
+					Nullable: true},
+				{Name: "null-i32", Type: arrow.PrimitiveTypes.Int32,
+					Nullable: true},
+				{Name: "null-i64", Type: arrow.PrimitiveTypes.Int64,
+					Nullable: true},
+				{Name: "null-ui8", Type: arrow.PrimitiveTypes.Uint8,
+					Nullable: true},
+				{Name: "null-ui16", Type: arrow.PrimitiveTypes.Uint16,
+					Nullable: true},
+				{Name: "null-ui32", Type: arrow.PrimitiveTypes.Uint32,
+					Nullable: true},
+				{Name: "null-ui64", Type: arrow.PrimitiveTypes.Uint64,
+					Nullable: true},
+				{Name: "null-f32", Type: arrow.PrimitiveTypes.Float32,
+					Nullable: true},
+				{Name: "null-f62", Type: arrow.PrimitiveTypes.Float64,
+					Nullable: true},
+				{Name: "null-d32", Type: arrow.PrimitiveTypes.Date32,
+					Nullable: true},
+				{Name: "null-d64", Type: arrow.PrimitiveTypes.Date64,
+					Nullable: true},
 			}, nil),
 			expectedParquetMetaData: []string{
-				"name=f1-i8, type=INT32, convertedtype=INT_8",
-				"name=f1-i16, type=INT32, convertedtype=INT_16",
-				"name=f1-i32, type=INT32, convertedtype=INT_32",
-				"name=f1-i64, type=INT64, convertedtype=INT_64",
-				"name=f1-ui8, type=INT32, convertedtype=UINT_8",
-				"name=f1-ui16, type=INT32, convertedtype=UINT_16",
-				"name=f1-ui32, type=INT32, convertedtype=UINT_32",
-				"name=f1-ui64, type=INT64, convertedtype=UINT_64",
-				"name=f1-f32, type=FLOAT",
-				"name=f1-f62, type=DOUBLE",
-				"name=f1-d32, type=INT32, convertedtype=DATE",
-				"name=f1-d64, type=INT32, convertedtype=DATE",
+				"name=f1-i8, type=INT32, convertedtype=INT_8, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-i16, type=INT32, convertedtype=INT_16, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-i32, type=INT32, repetitiontype=REQUIRED",
+				"name=f1-i64, type=INT64, repetitiontype=REQUIRED",
+				"name=f1-ui8, type=INT32, convertedtype=UINT_8, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-ui16, type=INT32, convertedtype=UINT_16, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-ui32, type=INT32, convertedtype=UINT_32, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-ui64, type=INT64, convertedtype=UINT_64, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-f32, type=FLOAT, repetitiontype=REQUIRED",
+				"name=f1-f62, type=DOUBLE, repetitiontype=REQUIRED",
+				"name=f1-d32, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-d64, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=REQUIRED",
+				"name=null-i8, type=INT32, convertedtype=INT_8, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-i16, type=INT32, convertedtype=INT_16, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-i32, type=INT32, repetitiontype=OPTIONAL",
+				"name=null-i64, type=INT64, repetitiontype=OPTIONAL",
+				"name=null-ui8, type=INT32, convertedtype=UINT_8, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-ui16, type=INT32, convertedtype=UINT_16, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-ui32, type=INT32, convertedtype=UINT_32, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-ui64, type=INT64, convertedtype=UINT_64, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-f32, type=FLOAT, repetitiontype=OPTIONAL",
+				"name=null-f62, type=DOUBLE, repetitiontype=OPTIONAL",
+				"name=null-d32, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-d64, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=OPTIONAL",
 			},
 			expectedErr: false,
 		},
@@ -51,10 +103,18 @@ func TestTypeConversion(t *testing.T) {
 			testSchema: arrow.NewSchema([]arrow.Field{
 				{Name: "f1-string", Type: arrow.BinaryTypes.String},
 				{Name: "f1-binary", Type: arrow.BinaryTypes.Binary},
+				{Name: "null-string", Type: arrow.BinaryTypes.String,
+					Nullable: true},
+				{Name: "null-binary", Type: arrow.BinaryTypes.Binary,
+					Nullable: true},
 			}, nil),
 			expectedParquetMetaData: []string{
-				"name=f1-string, type=BYTE_ARRAY, convertedtype=UTF8",
-				"name=f1-binary, type=BYTE_ARRAY",
+				"name=f1-string, type=BYTE_ARRAY, convertedtype=UTF8, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-binary, type=BYTE_ARRAY, repetitiontype=REQUIRED",
+				"name=null-string, type=BYTE_ARRAY, convertedtype=UTF8, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-binary, type=BYTE_ARRAY, repetitiontype=OPTIONAL",
 			},
 			expectedErr: false,
 		},
@@ -66,24 +126,54 @@ func TestTypeConversion(t *testing.T) {
 				{Name: "f1-d64", Type: arrow.FixedWidthTypes.Date64},
 				{Name: "f1-t32ms", Type: arrow.FixedWidthTypes.Time32ms},
 				{Name: "f1-tsms", Type: arrow.FixedWidthTypes.Timestamp_ms},
+				{Name: "null-bool", Type: arrow.FixedWidthTypes.Boolean,
+					Nullable: true},
+				{Name: "null-d32", Type: arrow.FixedWidthTypes.Date32,
+					Nullable: true},
+				{Name: "null-d64", Type: arrow.FixedWidthTypes.Date64,
+					Nullable: true},
+				{Name: "null-t32ms", Type: arrow.FixedWidthTypes.Time32ms,
+					Nullable: true},
+				{Name: "null-tsms", Type: arrow.FixedWidthTypes.Timestamp_ms,
+					Nullable: true},
 			}, nil),
 			expectedParquetMetaData: []string{
-				"name=f1-bool, type=BOOLEAN",
-				"name=f1-d32, type=INT32, convertedtype=DATE",
-				"name=f1-d64, type=INT32, convertedtype=DATE",
-				"name=f1-t32ms, type=INT32, convertedtype=TIME_MILLIS",
-				"name=f1-tsms, type=INT64, convertedtype=TIMESTAMP_MILLIS",
+				"name=f1-bool, type=BOOLEAN, repetitiontype=REQUIRED",
+				"name=f1-d32, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-d64, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-t32ms, type=INT32, convertedtype=TIME_MILLIS, " +
+					"repetitiontype=REQUIRED",
+				"name=f1-tsms, type=INT64, convertedtype=TIMESTAMP_MILLIS, " +
+					"repetitiontype=REQUIRED",
+				"name=null-bool, type=BOOLEAN, repetitiontype=OPTIONAL",
+				"name=null-d32, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-d64, type=INT32, convertedtype=DATE, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-t32ms, type=INT32, convertedtype=TIME_MILLIS, " +
+					"repetitiontype=OPTIONAL",
+				"name=null-tsms, type=INT64, convertedtype=TIMESTAMP_MILLIS, " +
+					"repetitiontype=OPTIONAL",
 			},
 			expectedErr: false,
 		},
 		{
 			title: "test non supported types",
 			testSchema: arrow.NewSchema([]arrow.Field{
-				{Name: "f1-bool", Type: arrow.FixedWidthTypes.Time64us},
-				{Name: "f1-d64", Type: arrow.FixedWidthTypes.Time64us},
-				{Name: "f1-d64", Type: arrow.FixedWidthTypes.Time32s},
-				{Name: "f1-d32", Type: arrow.FixedWidthTypes.Timestamp_ns},
-				{Name: "f1-d64", Type: arrow.FixedWidthTypes.Timestamp_s},
+				{Name: "f1-t64us", Type: arrow.FixedWidthTypes.Time64us},
+				{Name: "f1-t32s", Type: arrow.FixedWidthTypes.Time32s},
+				{Name: "f1-tsns", Type: arrow.FixedWidthTypes.Timestamp_ns},
+				{Name: "f1-tss", Type: arrow.FixedWidthTypes.Timestamp_s},
+				{Name: "null-t64us", Type: arrow.FixedWidthTypes.Time64us,
+					Nullable: true},
+				{Name: "null-t32s", Type: arrow.FixedWidthTypes.Time32s,
+					Nullable: true},
+				{Name: "null-tsns", Type: arrow.FixedWidthTypes.Timestamp_ns,
+					Nullable: true},
+				{Name: "null-tss", Type: arrow.FixedWidthTypes.Timestamp_s,
+					Nullable: true},
 			}, nil),
 			expectedParquetMetaData: []string{},
 			expectedErr:             true,

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -65,10 +65,7 @@ func (w *ArrowWriter) WriteArrow(record array.Record) error {
 	table := make([][]interface{}, 0)
 	for i, column := range record.Columns() {
 		columnFromRecord, err := common.ArrowColToParquetCol(
-			record.Schema().Field(i),
-			column,
-			column.Len(),
-			w.SchemaHandler.SchemaElements[i+1])
+			record.Schema().Field(i), column)
 
 		if err != nil {
 			return err

--- a/writer/arrow_test.go
+++ b/writer/arrow_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/apache/arrow/go/arrow"
@@ -15,8 +16,7 @@ import (
 )
 
 // testSchema is schema for the testint table which covers all
-// the types which we support from the arrow with two exceptions
-// which are left commented out
+// the types which we support from the arrow.
 var testSchema = arrow.NewSchema(
 	[]arrow.Field{
 		{Name: "int8", Type: arrow.PrimitiveTypes.Int8},
@@ -31,11 +31,11 @@ var testSchema = arrow.NewSchema(
 		{Name: "float64", Type: arrow.PrimitiveTypes.Float64},
 		{Name: "pt-date32", Type: arrow.PrimitiveTypes.Date32},
 		{Name: "pt-date64", Type: arrow.PrimitiveTypes.Date64},
-		//{Name: "fwt-date32", Type: arrow.FixedWidthTypes.Date32},
-		//{Name: "fwt-date64", Type: arrow.FixedWidthTypes.Date64},
 		{Name: "bin", Type: arrow.BinaryTypes.Binary},
 		{Name: "str", Type: arrow.BinaryTypes.String},
 		{Name: "bool", Type: arrow.FixedWidthTypes.Boolean},
+		{Name: "fwt-date32", Type: arrow.FixedWidthTypes.Date32},
+		{Name: "fwt-date64", Type: arrow.FixedWidthTypes.Date64},
 		{Name: "t32ms", Type: arrow.FixedWidthTypes.Time32ms},
 		{Name: "ts-ms", Type: arrow.FixedWidthTypes.Timestamp_ms},
 	},
@@ -166,6 +166,22 @@ func testRecord(mem memory.Allocator) array.Record {
 	}()
 	defer col15.Release()
 	col16 := func() array.Interface {
+		ib := array.NewDate32Builder(mem)
+		defer ib.Release()
+		ib.AppendValues([]arrow.Date32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			nil)
+		return ib.NewDate32Array()
+	}()
+	defer col16.Release()
+	col17 := func() array.Interface {
+		ib := array.NewDate64Builder(mem)
+		defer ib.Release()
+		ib.AppendValues([]arrow.Date64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			nil)
+		return ib.NewDate64Array()
+	}()
+	defer col17.Release()
+	col18 := func() array.Interface {
 		dtype := arrow.FixedWidthTypes.Time32ms
 		ib := array.NewTime32Builder(mem, dtype.(*arrow.Time32Type))
 		defer ib.Release()
@@ -175,8 +191,8 @@ func testRecord(mem memory.Allocator) array.Record {
 			arrow.Time32(9), arrow.Time32(10)}, nil)
 		return ib.NewTime32Array()
 	}()
-	defer col16.Release()
-	col17 := func() array.Interface {
+	defer col18.Release()
+	col19 := func() array.Interface {
 		dtype := arrow.FixedWidthTypes.Timestamp_ms
 		ib := array.NewTimestampBuilder(mem, dtype.(*arrow.TimestampType))
 		defer ib.Release()
@@ -184,18 +200,246 @@ func testRecord(mem memory.Allocator) array.Record {
 			nil)
 		return ib.NewTimestampArray()
 	}()
-	defer col17.Release()
+	defer col19.Release()
 	cols := []array.Interface{col1, col2, col3, col4, col5, col6, col7,
-		col8, col9, col10, col11, col12, col13, col14, col15, col16, col17}
+		col8, col9, col10, col11, col12, col13, col14, col15, col16, col17,
+		col18, col19}
 	return array.NewRecord(testSchema, cols, -1)
+}
+
+// testNullableSchema is schema for the testing the support for nullability
+// and covers all the types which we support from the arrow.
+var testNullableSchema = arrow.NewSchema(
+	[]arrow.Field{
+		{Name: "int8", Type: arrow.PrimitiveTypes.Int8, Nullable: true},
+		{Name: "int16", Type: arrow.PrimitiveTypes.Int16, Nullable: true},
+		{Name: "int32", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "int64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "uint8", Type: arrow.PrimitiveTypes.Uint8, Nullable: true},
+		{Name: "uint16", Type: arrow.PrimitiveTypes.Uint16, Nullable: true},
+		{Name: "uint32", Type: arrow.PrimitiveTypes.Uint32, Nullable: true},
+		{Name: "uint64", Type: arrow.PrimitiveTypes.Uint64, Nullable: true},
+		{Name: "float32", Type: arrow.PrimitiveTypes.Float32, Nullable: true},
+		{Name: "float64", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "pt-date32", Type: arrow.PrimitiveTypes.Date32, Nullable: true},
+		{Name: "pt-date64", Type: arrow.PrimitiveTypes.Date64, Nullable: true},
+		{Name: "bin", Type: arrow.BinaryTypes.Binary, Nullable: true},
+		{Name: "str", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "bool", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		{Name: "fwt-date32", Type: arrow.FixedWidthTypes.Date32,
+			Nullable: true},
+		{Name: "fwt-date64", Type: arrow.FixedWidthTypes.Date64,
+			Nullable: true},
+		{Name: "t32ms", Type: arrow.FixedWidthTypes.Time32ms, Nullable: true},
+		{Name: "ts-ms", Type: arrow.FixedWidthTypes.Timestamp_ms,
+			Nullable: true},
+	},
+	nil,
+)
+
+// testRecordWithNulls populates the schema testNullableSchema
+func testRecordWithNulls(mem memory.Allocator) array.Record {
+	col1 := func() array.Interface {
+		ib := array.NewInt8Builder(mem)
+		defer ib.Release()
+		ib.Append(-1)
+		ib.AppendNull()
+		ib.Append(-2)
+		ib.AppendNull()
+		return ib.NewInt8Array()
+	}()
+	defer col1.Release()
+	col2 := func() array.Interface {
+		ib := array.NewInt16Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(-11)
+		ib.AppendNull()
+		ib.Append(-12)
+		return ib.NewInt16Array()
+	}()
+	defer col2.Release()
+	col3 := func() array.Interface {
+		ib := array.NewInt32Builder(mem)
+		defer ib.Release()
+		ib.Append(-21)
+		ib.AppendNull()
+		ib.Append(-22)
+		ib.AppendNull()
+		return ib.NewInt32Array()
+	}()
+	defer col3.Release()
+	col4 := func() array.Interface {
+		ib := array.NewInt64Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(-31)
+		ib.AppendNull()
+		ib.Append(-32)
+		return ib.NewInt64Array()
+	}()
+	defer col4.Release()
+	col5 := func() array.Interface {
+		ib := array.NewUint8Builder(mem)
+		defer ib.Release()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		ib.AppendNull()
+		return ib.NewUint8Array()
+	}()
+	defer col5.Release()
+	col6 := func() array.Interface {
+		ib := array.NewUint16Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(11)
+		ib.AppendNull()
+		ib.Append(12)
+		return ib.NewUint16Array()
+	}()
+	defer col6.Release()
+	col7 := func() array.Interface {
+		ib := array.NewUint32Builder(mem)
+		defer ib.Release()
+		ib.Append(21)
+		ib.AppendNull()
+		ib.Append(22)
+		ib.AppendNull()
+		return ib.NewUint32Array()
+	}()
+	defer col7.Release()
+	col8 := func() array.Interface {
+		ib := array.NewUint64Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(31)
+		ib.AppendNull()
+		ib.Append(32)
+		return ib.NewUint64Array()
+	}()
+	defer col8.Release()
+	col9 := func() array.Interface {
+		ib := array.NewFloat32Builder(mem)
+		defer ib.Release()
+		ib.Append(1.1)
+		ib.AppendNull()
+		ib.Append(1.2)
+		ib.AppendNull()
+		return ib.NewFloat32Array()
+	}()
+	defer col9.Release()
+	col10 := func() array.Interface {
+		ib := array.NewFloat64Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(10.1)
+		ib.AppendNull()
+		ib.Append(10.2)
+		return ib.NewFloat64Array()
+	}()
+	defer col10.Release()
+	col11 := func() array.Interface {
+		ib := array.NewDate32Builder(mem)
+		defer ib.Release()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		ib.AppendNull()
+		return ib.NewDate32Array()
+	}()
+	defer col11.Release()
+	col12 := func() array.Interface {
+		ib := array.NewDate64Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		return ib.NewDate64Array()
+	}()
+	defer col12.Release()
+	col13 := func() array.Interface {
+		ib := array.NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+		defer ib.Release()
+		ib.Append([]byte("A"))
+		ib.AppendNull()
+		ib.Append([]byte("B"))
+		ib.AppendNull()
+		return ib.NewBinaryArray()
+	}()
+	defer col13.Release()
+	col14 := func() array.Interface {
+		ib := array.NewStringBuilder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append("a")
+		ib.AppendNull()
+		ib.Append("b")
+		return ib.NewStringArray()
+	}()
+	defer col14.Release()
+	col15 := func() array.Interface {
+		ib := array.NewBooleanBuilder(mem)
+		defer ib.Release()
+		ib.Append(true)
+		ib.AppendNull()
+		ib.Append(false)
+		ib.AppendNull()
+		return ib.NewBooleanArray()
+	}()
+	defer col15.Release()
+	col16 := func() array.Interface {
+		ib := array.NewDate32Builder(mem)
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		return ib.NewDate32Array()
+	}()
+	defer col16.Release()
+	col17 := func() array.Interface {
+		ib := array.NewDate64Builder(mem)
+		defer ib.Release()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		ib.AppendNull()
+		return ib.NewDate64Array()
+	}()
+	defer col17.Release()
+	col18 := func() array.Interface {
+		dtype := arrow.FixedWidthTypes.Time32ms
+		ib := array.NewTime32Builder(mem, dtype.(*arrow.Time32Type))
+		defer ib.Release()
+		ib.AppendNull()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		return ib.NewTime32Array()
+	}()
+	defer col18.Release()
+	col19 := func() array.Interface {
+		dtype := arrow.FixedWidthTypes.Timestamp_ms
+		ib := array.NewTimestampBuilder(mem, dtype.(*arrow.TimestampType))
+		defer ib.Release()
+		ib.Append(1)
+		ib.AppendNull()
+		ib.Append(2)
+		ib.AppendNull()
+		return ib.NewTimestampArray()
+	}()
+	defer col19.Release()
+	cols := []array.Interface{col1, col2, col3, col4, col5, col6, col7,
+		col8, col9, col10, col11, col12, col13, col14, col15, col16, col17,
+		col18, col19}
+	return array.NewRecord(testNullableSchema, cols, -1)
 }
 
 // TestE2EValid tests the whole cycle of creating a parquet file from arrow
 // covering all the currently supported types by using sequential writer
-// runing a single goroutine.
-// This test does not go through FixedWidthTypes of Date 32 and 64 as there
-// was no convenient way to mock this and the PrimitiveTypes of those are
-// used instead
+// running a single goroutine.
 func TestE2ESequentialValid(t *testing.T) {
 	var err error
 	ts := testSchema
@@ -231,16 +475,16 @@ func TestE2ESequentialValid(t *testing.T) {
 		actualTable = actualTable + fmt.Sprintf("%v", row)
 	}
 	expectedTable := "" +
-		"{-1 -11 -21 -31 1 11 21 31 1.1 10.1 1 1 [65] a true 1 1}" +
-		"{-2 -12 -22 -32 2 12 22 32 2.2 12.2 2 2 [66] b false 2 2}" +
-		"{-3 -13 -23 -33 3 13 23 33 3.3 13.3 3 3 [67] c true 3 3}" +
-		"{-4 -14 -24 -34 4 14 24 34 4.4 14.4 4 4 [68] d false 4 4}" +
-		"{-5 -15 -25 -35 5 15 25 35 5.5 15.5 5 5 [69] e true 5 5}" +
-		"{-6 -16 -26 -36 6 16 26 36 6.6 16.6 6 6 [70] f false 6 6}" +
-		"{-7 -17 -27 -37 7 17 27 37 7.7 17.7 7 7 [71] g true 7 7}" +
-		"{-8 -18 -28 -38 8 18 28 38 8.8 18.8 8 8 [72] h false 8 8}" +
-		"{-9 -19 -29 -39 9 19 29 39 9.9 19.9 9 9 [73] i true 9 9}" +
-		"{-10 -20 -30 -40 10 20 30 40 10.1 20.1 10 10 [74] j false 10 10}"
+		"{-1 -11 -21 -31 1 11 21 31 1.1 10.1 1 1 A a true 1 1 1 1}" +
+		"{-2 -12 -22 -32 2 12 22 32 2.2 12.2 2 2 B b false 2 2 2 2}" +
+		"{-3 -13 -23 -33 3 13 23 33 3.3 13.3 3 3 C c true 3 3 3 3}" +
+		"{-4 -14 -24 -34 4 14 24 34 4.4 14.4 4 4 D d false 4 4 4 4}" +
+		"{-5 -15 -25 -35 5 15 25 35 5.5 15.5 5 5 E e true 5 5 5 5}" +
+		"{-6 -16 -26 -36 6 16 26 36 6.6 16.6 6 6 F f false 6 6 6 6}" +
+		"{-7 -17 -27 -37 7 17 27 37 7.7 17.7 7 7 G g true 7 7 7 7}" +
+		"{-8 -18 -28 -38 8 18 28 38 8.8 18.8 8 8 H h false 8 8 8 8}" +
+		"{-9 -19 -29 -39 9 19 29 39 9.9 19.9 9 9 I i true 9 9 9 9}" +
+		"{-10 -20 -30 -40 10 20 30 40 10.1 20.1 10 10 J j false 10 10 10 10}"
 	assert.Equal(t, expectedTable, actualTable)
 
 	err = fw.Close()
@@ -253,10 +497,6 @@ func TestE2ESequentialValid(t *testing.T) {
 // TestE2EConcurrentValid tests the whole cycle of creating a parquet file
 // from arrow covering all the currently supported types by using a
 // concurrent writer running four goroutines
-//
-// This test does not go through FixedWidthTypes of Date 32 and 64 as there
-// was no convenient way to mock this and the PrimitiveTypes of those are
-// used instead
 func TestE2EConcurrentValid(t *testing.T) {
 	var err error
 	ts := testSchema
@@ -292,16 +532,16 @@ func TestE2EConcurrentValid(t *testing.T) {
 		actualTable = actualTable + fmt.Sprintf("%v", row)
 	}
 	expectedTable := "" +
-		"{-1 -11 -21 -31 1 11 21 31 1.1 10.1 1 1 [65] a true 1 1}" +
-		"{-2 -12 -22 -32 2 12 22 32 2.2 12.2 2 2 [66] b false 2 2}" +
-		"{-3 -13 -23 -33 3 13 23 33 3.3 13.3 3 3 [67] c true 3 3}" +
-		"{-4 -14 -24 -34 4 14 24 34 4.4 14.4 4 4 [68] d false 4 4}" +
-		"{-5 -15 -25 -35 5 15 25 35 5.5 15.5 5 5 [69] e true 5 5}" +
-		"{-6 -16 -26 -36 6 16 26 36 6.6 16.6 6 6 [70] f false 6 6}" +
-		"{-7 -17 -27 -37 7 17 27 37 7.7 17.7 7 7 [71] g true 7 7}" +
-		"{-8 -18 -28 -38 8 18 28 38 8.8 18.8 8 8 [72] h false 8 8}" +
-		"{-9 -19 -29 -39 9 19 29 39 9.9 19.9 9 9 [73] i true 9 9}" +
-		"{-10 -20 -30 -40 10 20 30 40 10.1 20.1 10 10 [74] j false 10 10}"
+		"{-1 -11 -21 -31 1 11 21 31 1.1 10.1 1 1 A a true 1 1 1 1}" +
+		"{-2 -12 -22 -32 2 12 22 32 2.2 12.2 2 2 B b false 2 2 2 2}" +
+		"{-3 -13 -23 -33 3 13 23 33 3.3 13.3 3 3 C c true 3 3 3 3}" +
+		"{-4 -14 -24 -34 4 14 24 34 4.4 14.4 4 4 D d false 4 4 4 4}" +
+		"{-5 -15 -25 -35 5 15 25 35 5.5 15.5 5 5 E e true 5 5 5 5}" +
+		"{-6 -16 -26 -36 6 16 26 36 6.6 16.6 6 6 F f false 6 6 6 6}" +
+		"{-7 -17 -27 -37 7 17 27 37 7.7 17.7 7 7 G g true 7 7 7 7}" +
+		"{-8 -18 -28 -38 8 18 28 38 8.8 18.8 8 8 H h false 8 8 8 8}" +
+		"{-9 -19 -29 -39 9 19 29 39 9.9 19.9 9 9 I i true 9 9 9 9}" +
+		"{-10 -20 -30 -40 10 20 30 40 10.1 20.1 10 10 J j false 10 10 10 10}"
 	assert.Equal(t, expectedTable, actualTable)
 
 	err = fw.Close()
@@ -309,6 +549,90 @@ func TestE2EConcurrentValid(t *testing.T) {
 	pr.ReadStop()
 	err = parquetFile.Close()
 	assert.Nil(t, err)
+}
+
+// TestE2NullabilityValid tests the whole cycle of creating a parquet file
+// from arrow record which contains Null values covering all the currently
+// supported types by using schema in which all fields are marked Nullable.
+func TestE2ENullabilityValid(t *testing.T) {
+	var err error
+	ts := testNullableSchema
+
+	buf := new(bytes.Buffer)
+	fw := writerfile.NewWriterFile(buf)
+	assert.Nil(t, err)
+
+	w, err := NewArrowWriter(ts, fw, 1)
+	assert.Nil(t, err)
+
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	rec := testRecordWithNulls(mem)
+	defer rec.Release()
+	err = w.WriteArrow(rec)
+	assert.Nil(t, err)
+
+	err = w.WriteStop()
+	assert.Nil(t, err)
+
+	parquetFile, err := buffer.NewBufferFile(buf.Bytes())
+	assert.Nil(t, err)
+
+	pr, err := reader.NewParquetReader(parquetFile, nil, 1)
+	assert.Nil(t, err)
+
+	num := int(pr.GetNumRows())
+	res, err := pr.ReadByNumber(num)
+	assert.Nil(t, err)
+
+	actualTable := [][]interface{}{}
+	for _, row := range res {
+		actualTable = append(actualTable, rowToSliceOfValues(row))
+	}
+	expectedTable := [][]interface{}{
+		{-1, nil, -21, nil, 1, nil, 21, nil, 1.1, nil, 1, nil, "A", nil, true,
+			nil, 1, nil, 1},
+
+		{nil, -11, nil, -31, nil, 11, nil, 31, nil, 10.1, nil, 1, nil, "a",
+			nil, 1, nil, 1, nil},
+
+		{-2, nil, -22, nil, 2, nil, 22, nil, 1.2, nil, 2, nil, "B", nil, false,
+			nil, 2, nil, 2},
+
+		{nil, -12, nil, -32, nil, 12, nil, 32, nil, 10.2, nil, 2, nil, "b",
+			nil, 2, nil, 2, nil},
+	}
+	assert.Equal(t, len(expectedTable), len(actualTable))
+	assert.Equal(t, len(expectedTable[0]), len(actualTable[0]))
+	for i := range expectedTable {
+		for j := range expectedTable[i] {
+			assert.EqualValues(t, expectedTable[i][j], actualTable[i][j],
+				"mismatch at: [%d][%d]", i, j)
+		}
+	}
+
+	err = fw.Close()
+	assert.Nil(t, err)
+	pr.ReadStop()
+	err = parquetFile.Close()
+	assert.Nil(t, err)
+}
+
+func rowToSliceOfValues(s interface{}) []interface{} {
+	v := reflect.ValueOf(s)
+	res := []interface{}{}
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.IsNil() {
+			res = append(res, nil)
+			continue
+		}
+		if field.Type().Kind() == reflect.Ptr {
+			res = append(res, field.Elem().Interface())
+		} else {
+			res = append(res, field.Interface())
+		}
+	}
+	return res
 }
 
 func BenchmarkWrite(b *testing.B) {


### PR DESCRIPTION
Adding support for Nullability to the arrow integration by:
1. Translating the Nullability attribute from arrow Schema fields
   to repetitiontype in the tags that are generated by
   schema.ConvertArrowToParquetSchema func.
2. Extending the marshal.MarshalArrow to handle optional values
   following how this is made in marshal.MarshalCSV.
3. Fixing the common.ArrowColToParquetCol to properly handle
   Nulls and removing unnecessary conversions to string and back
   to a value which only resulted in type casts which are now
   done inline where needed which also simplifies the code and
   improves the performance.
4. Removing the exception for the FixedWidthTypes.Date32 and .Date64
   in writer/arrow_test.go since they are defined the same way as the
   primitive equivalents and thus they use the same value type and they
   can be easily mocked with Date32/64Builders.
5. Extending the example in example/arrow_to_parquet.go to contain
   int32 field that is marked as Nullable.

This change is tested by:
Extending the tests in schema/arrow_test.go and adding new test
in writer/arrow_test.go.

This change makes the following API change:
removing the `len` and `el` arguments from common.ArrowColToParquetCol
which are no longer used.

Signed-off-by: Ivo Stratev <istratev@vmware.com>

Closes #474