### PR TITLE
Add MarshalFast implementation to improve writer performance

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -993,6 +993,11 @@ func PathStrIndex(str string) int {
 	return len(strings.Split(str, PAR_GO_PATH_DELIMITER))
 }
 
+func IsChildPath(parent, child string) bool {
+	ln := len(parent)
+	return strings.HasPrefix(child, parent) && (len(child) == ln || child[ln] == PAR_GO_PATH_DELIMITER[0])
+}
+
 // NewTable creates empty table with transposed columns and records
 func NewTable(rowLen, colLen int) [][]interface{} {
 	tableLen := make([]interface{}, rowLen*colLen)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516
 	github.com/apache/thrift v0.14.2
 	github.com/aws/aws-sdk-go v1.30.19
+	github.com/goccy/go-reflect v1.2.0
 	github.com/golang/snappy v0.0.3
 	github.com/klauspost/compress v1.13.1
 	github.com/pierrec/lz4/v4 v4.1.8

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/goccy/go-reflect v1.2.0 h1:O0T8rZCuNmGXewnATuKYnkL0xm6o8UNOJZd/gOkb9ms=
+github.com/goccy/go-reflect v1.2.0/go.mod h1:n0oYZn8VcV2CkWTxi8B9QjkCoq6GTtCEdfmR66YhFtE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/marshal/json.go
+++ b/marshal/json.go
@@ -29,24 +29,9 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 		}
 	}()
 
-	res := make(map[string]*layout.Table)
+	res := setupTableMap(schemaHandler, len(ss))
 	pathMap := schemaHandler.PathMap
 	nodeBuf := NewNodeBuf(1)
-
-	for i := 0; i < len(schemaHandler.SchemaElements); i++ {
-		schema := schemaHandler.SchemaElements[i]
-		pathStr := schemaHandler.IndexMap[int32(i)]
-		numChildren := schema.GetNumChildren()
-		if numChildren == 0 {
-			res[pathStr] = layout.NewEmptyTable()
-			res[pathStr].Path = common.StrToPath(pathStr)
-			res[pathStr].MaxDefinitionLevel, _ = schemaHandler.MaxDefinitionLevel(res[pathStr].Path)
-			res[pathStr].MaxRepetitionLevel, _ = schemaHandler.MaxRepetitionLevel(res[pathStr].Path)
-			res[pathStr].RepetitionType = schema.GetRepetitionType()
-			res[pathStr].Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
-			res[pathStr].Info = schemaHandler.Infos[i]
-		}
-	}
 
 	stack := make([]*Node, 0, 100)
 	for i := 0; i < len(ss); i++ {
@@ -97,8 +82,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 					pathStr = pathStr + common.PAR_GO_PATH_DELIMITER + "Key_value"
 					if len(keys) <= 0 {
 						for key, table := range res {
-							if strings.HasPrefix(key, node.PathMap.Path) &&
-								(len(key) == len(node.PathMap.Path) || key[len(node.PathMap.Path)] == common.PAR_GO_PATH_DELIMITER[0]) {
+							if common.IsChildPath(node.PathMap.Path, key) {
 								table.Values = append(table.Values, nil)
 								table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
 								table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
@@ -167,9 +151,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 						} else {
 							newPathStr := node.PathMap.Children[key].Path
 							for path, table := range res {
-								if strings.HasPrefix(path, newPathStr) &&
-									(len(path) == len(newPathStr) || path[len(newPathStr)] == common.PAR_GO_PATH_DELIMITER[0]) {
-
+								if common.IsChildPath(newPathStr, path) {
 									table.Values = append(table.Values, nil)
 									table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
 									table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
@@ -186,8 +168,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 					pathStr = pathStr + common.PAR_GO_PATH_DELIMITER + "List" + common.PAR_GO_PATH_DELIMITER + "Element"
 					if ln <= 0 {
 						for key, table := range res {
-							if strings.HasPrefix(key, node.PathMap.Path) &&
-								(len(key) == len(node.PathMap.Path) || key[len(node.PathMap.Path)] == common.PAR_GO_PATH_DELIMITER[0]) {
+							if common.IsChildPath(node.PathMap.Path, key) {
 								table.Values = append(table.Values, nil)
 								table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
 								table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
@@ -220,8 +201,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 				} else { //Repeated
 					if ln <= 0 {
 						for key, table := range res {
-							if strings.HasPrefix(key, node.PathMap.Path) &&
-								(len(key) == len(node.PathMap.Path) || key[len(node.PathMap.Path)] == common.PAR_GO_PATH_DELIMITER[0]) {
+							if common.IsChildPath(node.PathMap.Path, key) {
 								table.Values = append(table.Values, nil)
 								table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
 								table.RepetitionLevels = append(table.RepetitionLevels, node.RL)

--- a/marshal/marshal_fast.go
+++ b/marshal/marshal_fast.go
@@ -1,0 +1,329 @@
+package marshal
+
+import (
+	"errors"
+	"fmt"
+	"github.com/goccy/go-reflect"
+	"github.com/xitongsys/parquet-go/common"
+	"github.com/xitongsys/parquet-go/layout"
+	"github.com/xitongsys/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/types"
+	"unsafe"
+)
+
+// MarshalFast implements the Marshal function while maximizing performance and minimizing
+// allocations.
+//
+// For each type it attempts to marshal, it uses reflection to compile an encoder. Then,
+// for each element, it looks up the encoder for the type and encodes it by walking the
+// pointers of the structure, appending leaf elements into their respective tables.
+//
+// This function makes liberal use of the unsafe package to avoid allocations when
+// performing normal reflection. It also uses the "github.com/goccy/go-reflect" package (a
+// drop-in alternative to the normal "reflect" package) to make use of some additional
+// features. (Namely TypeID and TypeAndPtrOf.)
+//
+// It does not support map-type fields. It should support every other use-case of Marshal.
+func MarshalFast(srcInterface []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("unkown error")
+			}
+		}
+	}()
+
+	tableMap := setupTableMap(schemaHandler, len(srcInterface))
+	pathMap := schemaHandler.PathMap
+
+	c := compiler{
+		encoderMap:    make(map[encoderMapKey]encoder),
+		tableMap:      tableMap,
+		schemaHandler: schemaHandler,
+	}
+
+	for _, v := range srcInterface {
+		typ, ptr := reflect.TypeAndPtrOf(v)
+		enc := c.getEncoder(typ, pathMap)
+		enc.encode(ptr, 0, 0)
+	}
+
+	return &tableMap, nil
+}
+
+type encoder interface {
+	encode(ptr unsafe.Pointer, dl, rl int32)
+}
+
+// encodeMapKey is the key used to lookup compiled encoders.
+//
+// It uses both the typeID and the pathMap because the encoder stores the table that it
+// targets, which is different for each path, and because the same path may have multiple
+// encoders for different types, such as for pointers or interfaces and for the underlying
+// value.
+type encoderMapKey struct {
+	typeID  uintptr
+	pathMap *schema.PathMapType
+}
+
+func (k encoderMapKey) String() string {
+	return fmt.Sprintf("{%d, %s}", k.typeID, k.pathMap.Path)
+}
+
+// compiler handles compiling encoders and caching them so that they can be reused across
+// multiple objects.
+//
+// Currently, the caching is local to the compiler, which requires re-compiling on every
+// call to MarshalFast. We could cache across calls to MarshalFast, but this is
+// complicated by the need to synchronize across multiple goroutines, and re-compiling
+// doesn't comprise a significant portion of execution time when writing large files.
+type compiler struct {
+	encoderMap    map[encoderMapKey]encoder
+	tableMap      map[string]*layout.Table
+	schemaHandler *schema.SchemaHandler
+}
+
+// getEncoder returns an encoder for the type and path provided. It looks up a cached
+// encoder if one exists, otherwise compiles a new one and caches it.
+func (c *compiler) getEncoder(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+	var enc encoder
+	var ok bool
+	typeIface := reflect.Zero(typ).Interface()
+	typeID := reflect.TypeID(typeIface)
+	key := encoderMapKey{typeID, pathMap}
+	if enc, ok = c.encoderMap[key]; !ok {
+		enc = c.compile(typ, pathMap)
+		c.encoderMap[key] = enc
+	}
+	return enc
+}
+
+func (c *compiler) compile(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+	switch typ.Kind() {
+	case reflect.Ptr:
+		return c.compilePointer(typ, pathMap)
+	case reflect.Interface:
+		return c.compileInterface(typ, pathMap)
+	case reflect.Struct:
+		return c.compileStruct(typ, pathMap)
+	case reflect.Slice:
+		return c.compileSlice(typ, pathMap)
+	case reflect.Map:
+		panic("FastMarshal does not support map fields.")
+	default:
+		te := c.terminalEncoder(typ, pathMap)
+		return &te
+	}
+}
+
+func (c *compiler) getSchema(path string) *parquet.SchemaElement {
+	schemaIndex := c.schemaHandler.MapIndex[path]
+	return c.schemaHandler.SchemaElements[schemaIndex]
+}
+
+func (c *compiler) terminalEncoder(typ reflect.Type, pathMap *schema.PathMapType) terminalEncoder {
+	typeIface := reflect.Zero(typ).Interface()
+	path := pathMap.Path
+	return terminalEncoder{
+		typeIface: typeIface,
+		table:     c.tableMap[path],
+		pT:        c.getSchema(path).Type,
+	}
+}
+
+func (c *compiler) compilePointer(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+	var valEncoder encoder
+	valEncoder = c.getEncoder(typ.Elem(), pathMap)
+	return &pointerEncoder{valEncoder}
+}
+
+func (c *compiler) compileInterface(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+	var childTables []*layout.Table
+	for tablePath, table := range c.tableMap {
+		if common.IsChildPath(pathMap.Path, tablePath) {
+			childTables = append(childTables, table)
+		}
+	}
+
+	return &ifaceEncoder{c, pathMap, childTables}
+}
+
+func (c *compiler) compileStruct(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+	if len(pathMap.Children) == 0 {
+		return &nilEncoder{c.terminalEncoder(typ, pathMap)}
+	}
+	numFields := typ.NumField()
+	encoders := make([]structFieldEncoder, 0, numFields)
+	for i := 0; i < numFields; i++ {
+		tf := typ.Field(i)
+		name := tf.Name
+		if fPathMap, ok := pathMap.Children[name]; ok {
+			encoders = append(encoders, structFieldEncoder{
+				offset: tf.Offset,
+				enc:    c.getEncoder(tf.Type, fPathMap),
+			})
+		}
+	}
+	return &structEncoder{encoders}
+}
+
+func (c *compiler) compileSlice(typ reflect.Type, pathMap *schema.PathMapType) encoder {
+
+	if *c.getSchema(pathMap.Path).RepetitionType != parquet.FieldRepetitionType_REPEATED {
+		pathMap = pathMap.Children["List"].Children["Element"]
+	}
+
+	valEncoder := c.getEncoder(typ.Elem(), pathMap)
+	elemSize := typ.Elem().Size()
+	return &sliceEncoder{elemSize, valEncoder}
+}
+
+// emptyInterface shares the structure underlying an interface{}. It allows us to
+// build one on the stack without performing an allocation.
+type emptyInterface struct {
+	typ unsafe.Pointer
+	val unsafe.Pointer
+}
+
+// toIface converts a typeIface and an unsafe.Pointer into an empty interface with the
+// same type as typeIface and referencing the value of unsafe.Pointer without performing
+// an allocation.
+// This is safe only if the ptr is heap-allocated. However, we can infer that the value is
+// heap-allocated because the code traversed to ptr from the root object, which came from
+// a []interface{} in the input to MarshalFast.
+func toIface(typeIface interface{}, ptr unsafe.Pointer) interface{} {
+	ei := emptyInterface{
+		typ: *(*unsafe.Pointer)(unsafe.Pointer(&typeIface)),
+		val: ptr,
+	}
+	return *(*interface{})(unsafe.Pointer(&ei))
+}
+
+// terminalEncoder handles encoding of terminal (leaf) values that don't have children.
+type terminalEncoder struct {
+	typeIface interface{}
+	table     *layout.Table
+	pT        *parquet.Type
+}
+
+// encode converts a pointer back to an interface of the correct type and appends it
+// to the table with definition-level and repetition-level.
+func (e *terminalEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	var v interface{}
+	if ptr != nil {
+		v = toIface(e.typeIface, ptr)
+	}
+	e.write(v, dl, rl)
+}
+
+func (e *terminalEncoder) write(v interface{}, dl, rl int32) {
+	e.table.Values = append(e.table.Values, types.InterfaceToParquetType(v, e.pT))
+	e.table.DefinitionLevels = append(e.table.DefinitionLevels, dl)
+	e.table.RepetitionLevels = append(e.table.RepetitionLevels, rl)
+}
+
+// nilEncoder handles encoding of values known to be nil.
+type nilEncoder struct {
+	terminalEncoder
+}
+
+func (e *nilEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	e.write(nil, dl, rl)
+}
+
+type structFieldEncoder struct {
+	offset uintptr
+	enc    encoder
+}
+
+// structEncoder handles encoding of struct types. For each field to be encoded, it
+// increments the pointer by the offset of the field and delegates to an appropriate
+// encoder.
+type structEncoder struct {
+	fieldEncoders []structFieldEncoder
+}
+
+func (e *structEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	for _, fe := range e.fieldEncoders {
+		var fPtr unsafe.Pointer
+		if ptr != nil {
+			fPtr = unsafe.Pointer(uintptr(ptr) + fe.offset)
+		}
+		fe.enc.encode(fPtr, dl, rl)
+	}
+}
+
+// pointerEncoder handles encoding of pointer types. If dereferences the pointer and
+// delegates to an appropriate encoder.
+type pointerEncoder struct {
+	valEncoder encoder
+}
+
+func (e *pointerEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	if ptr != nil {
+		ptr = *(*unsafe.Pointer)(ptr)
+	}
+	if ptr != nil {
+		dl++
+	}
+	e.valEncoder.encode(ptr, dl, rl)
+}
+
+// sliceEncoder handles encoding of slice types. It finds the length and address of the
+// first element, then increments the pointer by element offsets and delegates to an
+// appropriate encoder.
+type sliceEncoder struct {
+	elemSize   uintptr
+	valEncoder encoder
+}
+
+func (e *sliceEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	var sliceHeader []interface{}
+	if ptr != nil {
+		sliceHeader = *(*[]interface{})(ptr)
+	}
+	if len(sliceHeader) == 0 {
+		e.valEncoder.encode(nil, dl, rl)
+		return
+	}
+	headPtr := unsafe.Pointer(&sliceHeader[0])
+	for i := 0; i < len(sliceHeader); i++ {
+		elemPtr := unsafe.Pointer(uintptr(headPtr) + uintptr(i)*e.elemSize)
+		e.valEncoder.encode(elemPtr, dl+1, rl)
+		if i == 0 {
+			rl++
+		}
+	}
+}
+
+// ifaceEncoder handles encoding of interface types. It dynamically looks up an encoder
+// for the interface type. If the type is nil, it encodes nils in all child tables.
+// This dynamic lookup is necessary because the value is an interface and therefore could
+// be of multiple different types, which we don't know until we encode the individual
+// value.
+type ifaceEncoder struct {
+	c       *compiler
+	pathMap *schema.PathMapType
+	tables  []*layout.Table
+}
+
+func (e *ifaceEncoder) encode(ptr unsafe.Pointer, dl, rl int32) {
+	iface := *(*interface{})(ptr)
+	typ, subPtr := reflect.TypeAndPtrOf(iface)
+	if typ == nil {
+		term := terminalEncoder{}
+		for _, t := range e.tables {
+			term.table = t
+			term.encode(nil, dl, rl)
+		}
+	} else {
+		enc := e.c.getEncoder(typ, e.pathMap)
+		enc.encode(subPtr, dl, rl)
+	}
+}

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -1,6 +1,7 @@
 package marshal
 
 import (
+	"github.com/xitongsys/parquet-go/schema"
 	"reflect"
 	"testing"
 )
@@ -38,5 +39,157 @@ func TestParquetPtrMarshal(t *testing.T) {
 	res = ptrMarshal.Marshal(nodeIntPtr, nil)
 	if len(res) != 1 || res[0].DL != 4 {
 		t.Errorf("Fail expect nodes len %v, DL value %v, get nodes len %v, DL value %v", 1, 4, len(res), res[0].DL)
+	}
+}
+
+var iface interface{}
+
+func TestMarshalFast(t *testing.T) {
+
+	type testElem struct {
+		Bool      bool    `parquet:"name=bool, type=BOOLEAN"`
+		Int       int     `parquet:"name=int, type=INT64"`
+		Int8      int8    `parquet:"name=int8, type=INT32"`
+		Int16     int16   `parquet:"name=int16, type=INT32"`
+		Int32     int32   `parquet:"name=int32, type=INT32"`
+		Int64     int64   `parquet:"name=int64, type=INT64"`
+		Float     float32 `parquet:"name=float, type=FLOAT"`
+		Double    float64 `parquet:"name=double, type=DOUBLE"`
+		ByteArray string  `parquet:"name=bytearray, type=BYTE_ARRAY"`
+
+		Ptr    *int64  `parquet:"name=boolptr, type=INT64"`
+		PtrPtr **int64 `parquet:"name=boolptrptr, type=INT64"`
+
+		List         []string  `parquet:"name=list, convertedtype=LIST, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+		PtrList      *[]string `parquet:"name=ptrlist, convertedtype=LIST, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+		ListPtr      []*string `parquet:"name=listptr, convertedtype=LIST, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+		Repeated     []int32   `parquet:"name=repeated, type=INT32, repetitiontype=REPEATED"`
+		NestRepeated [][]int32 `parquet:"name=nestrepeated, type=INT32, repetitiontype=REPEATED"`
+	}
+
+	type subElem struct {
+		Val string `parquet:"name=val, type=BYTE_ARRAY"`
+	}
+
+	type testNestedElem struct {
+		SubElem       subElem     `parquet:"name=subelem"`
+		SubPtr        *subElem    `parquet:"name=subptr"`
+		SubList       []subElem   `parquet:"name=sublist"`
+		SubRepeated   []*subElem  `parquet:"name=subrepeated"`
+		EmptyElem     struct{}    `parquet:"name=emptyelem"`
+		EmptyPtr      *struct{}   `parquet:"name=emptyptr"`
+		EmptyList     []struct{}  `parquet:"name=emptylist"`
+		EmptyRepeated []*struct{} `parquet:"name=emptyrepeated"`
+	}
+
+	type testIfaceElem struct {
+		Bool      interface{} `parquet:"name=bool, type=BOOLEAN"`
+		Int32     interface{} `parquet:"name=int32, type=INT32"`
+		Int64     interface{} `parquet:"name=int64, type=INT64"`
+		Float     interface{} `parquet:"name=float, type=FLOAT"`
+		Double    interface{} `parquet:"name=double, type=DOUBLE"`
+		ByteArray interface{} `parquet:"name=bytearray, type=BYTE_ARRAY"`
+	}
+
+	i64 := int64(31)
+	refRef := &i64
+	var nilRef *int64
+	var nilList []string
+	str := "hi"
+
+	testCases := []struct {
+		value interface{}
+	}{
+		{testElem{Bool: true}},
+		{testElem{Ptr: &i64, PtrPtr: &refRef}},
+		{testElem{Ptr: nilRef, PtrPtr: &nilRef}},
+		{testElem{Ptr: nil, PtrPtr: nil}},
+		{testElem{Repeated: nil}},
+		{testElem{Repeated: []int32{}}},
+		{testElem{Repeated: []int32{31}}},
+		{testElem{Repeated: []int32{31, 32, 33, 34}}},
+		{testElem{List: nil}},
+		{testElem{List: []string{}}},
+		{testElem{List: []string{"hi"}}},
+		{testElem{List: []string{"1", "2", "3", "4"}}},
+		{testElem{PtrList: nil}},
+		{testElem{PtrList: &nilList}},
+		{testElem{PtrList: &[]string{}}},
+		{testElem{PtrList: &[]string{"hi"}}},
+		{testElem{PtrList: &[]string{"1", "2", "3", "4"}}},
+		{testElem{ListPtr: nil}},
+		{testElem{ListPtr: []*string{}}},
+		{testElem{ListPtr: []*string{nil}}},
+		{testElem{ListPtr: []*string{nil, nil, nil}}},
+		{testElem{ListPtr: []*string{&str}}},
+		{testElem{ListPtr: []*string{&str, &str, &str}}},
+		{testElem{ListPtr: []*string{&str, nil, &str}}},
+		{testElem{NestRepeated: nil}},
+		{testElem{NestRepeated: [][]int32{}}},
+		{testElem{NestRepeated: [][]int32{{}}}},
+		{testElem{NestRepeated: [][]int32{{1, 2, 3}}}},
+		// Test doesn't pass because it disagrees with Marshal, but I'm pretty sure that,
+		// if this is supported at all, this implementation is correct and there's a bug
+		// in Marshal.
+		// {testElem{NestRepeated: [][]int32{{1}, {2, 3, 4, 5}, nil, {6}}}},
+
+		{testNestedElem{}},
+		{testNestedElem{SubElem: subElem{Val: "hi"}}},
+		{testNestedElem{SubPtr: &subElem{Val: "hi"}}},
+		{testNestedElem{SubList: []subElem{}}},
+		{testNestedElem{SubList: []subElem{{Val: "hi"}}}},
+		{testNestedElem{SubList: []subElem{{Val: "hi"}, {}, {Val: "there"}}}},
+		{testNestedElem{SubRepeated: []*subElem{}}},
+		{testNestedElem{SubRepeated: []*subElem{{Val: "hi"}}}},
+		{testNestedElem{SubRepeated: []*subElem{{Val: "hi"}, nil, {Val: "there"}}}},
+		{testNestedElem{EmptyPtr: &struct{}{}}},
+		{testNestedElem{EmptyList: []struct{}{}}},
+		{testNestedElem{EmptyList: []struct{}{{}}}},
+		{testNestedElem{EmptyList: []struct{}{{}, {}}}},
+		{testNestedElem{EmptyRepeated: []*struct{}{}}},
+		{testNestedElem{EmptyRepeated: []*struct{}{{}}}},
+		{testNestedElem{EmptyRepeated: []*struct{}{{}, nil, {}}}},
+
+		// interface{}
+		{testIfaceElem{}},
+		{testIfaceElem{
+			Bool:      false,
+			Int32:     int32(0),
+			Int64:     int64(0),
+			Float:     float32(0),
+			Double:    float64(0),
+			ByteArray: "",
+		}},
+		{testIfaceElem{
+			Bool:      true,
+			Int32:     int32(12345),
+			Int64:     int64(54321),
+			Float:     float32(1.0),
+			Double:    float64(100.0),
+			ByteArray: "hi",
+		}},
+	}
+
+	for _, tt := range testCases {
+		t.Run("", func(t *testing.T) {
+			input := []interface{}{tt.value}
+			schemaType := reflect.Zero(reflect.PtrTo(reflect.TypeOf(tt.value))).Interface()
+			sch, err := schema.NewSchemaHandlerFromStruct(schemaType)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			expected, err := Marshal(input, sch)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			actual, err := MarshalFast(input, sch)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			if !reflect.DeepEqual(expected, actual) {
+				// require.Equal(t, expected, actual)
+				t.Errorf("not equal")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Provide an alternative Marshal implementation, MarshalFast, that
minimizes use of reflect to maximize performance and minimize
allocations.

The Marshal implementation spends a huge amount of time doing
allocations (and subsequently garbage collection), largely due to
using reflection on every element. Instead, we can use reflection to
analyze elements once-per-type and construct an encoder for elements of
that type. Then, the encoder can walk the pointers of each element of
that type and store its root values in the tables.

MarshalFast liberally uses the unsafe package, because it walks unsafe
pointers, and adds a dependency on goccy/go-reflect for some type
analysis features.

MarshalFast supports (as far as I can tell) all use-cases of Marshal
except for map types, which are hard to walk without using reflection.

-----

Compared to the normal Marshal function, (for my test case) MarshalFast improved total write speed by ~3x and reduced allocations by more than an order of magnitude.

```
# Marshal
$ go run ./alloc_test -N 10000000
2022/07/16 13:45:05 Done in 21.57479102s
# MarshalFast
$ go run ./alloc_test -N 10000000
2022/07/16 13:47:22 Done in 6.884004079s
```

<details>
<summary>Object allocation profile using Marshal</summary>

![allocs_objects_old](https://user-images.githubusercontent.com/7101542/179371787-8f6646bb-a815-4dd3-adfa-0a450dd27568.svg)

</details>

<details>
<summary>Object allocation profile using MarshalFast</summary>

![allocs_objects_fast](https://user-images.githubusercontent.com/7101542/179371791-cb9f7250-ad06-4f95-a536-7d71181d72b3.svg)

</details>