### PR TITLE
replace `ioutil.ReadAll` with `io.ReadAll`

### DIFF
--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -5,10 +5,11 @@ package compress
 
 import (
 	"bytes"
+	"io"
+	"sync"
+
 	"github.com/klauspost/compress/gzip"
 	"github.com/xitongsys/parquet-go/parquet"
-	"io/ioutil"
-	"sync"
 )
 
 var gzipWriterPool sync.Pool
@@ -34,7 +35,7 @@ func init() {
 		Uncompress: func(buf []byte) (i []byte, err error) {
 			rbuf := bytes.NewReader(buf)
 			gzipReader, _ := gzip.NewReader(rbuf)
-			res, err := ioutil.ReadAll(gzipReader)
+			res, err := io.ReadAll(gzipReader)
 			return res, err
 		},
 	}

--- a/compress/lz4.go
+++ b/compress/lz4.go
@@ -5,7 +5,7 @@ package compress
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"sync"
 
 	"github.com/pierrec/lz4/v4"
@@ -32,7 +32,7 @@ func init() {
 		Uncompress: func(buf []byte) (i []byte, err error) {
 			rbuf := bytes.NewReader(buf)
 			lz4Reader := lz4.NewReader(rbuf)
-			res, err := ioutil.ReadAll(lz4Reader)
+			res, err := io.ReadAll(lz4Reader)
 			return res, err
 		},
 	}


### PR DESCRIPTION
`"io/ioutil"` has been deprecated since Go 1.16.

https://tip.golang.org/doc/go1.16#ioutil