### PR TITLE
Fix: Handle byte to decimal conversion for negative numbers divisible by 16

### DIFF
--- a/types/converter.go
+++ b/types/converter.go
@@ -135,10 +135,12 @@ func DECIMAL_BYTE_ARRAY_ToString(dec []byte, precision int, scale int) string {
 		for i := range dec {
 			dec[i] = dec[i] ^ 0xff
 		}
-		dec[len(dec)-1] += 1
 	}
 	a := new(big.Int)
 	a.SetBytes(dec)
+	if sign == "-" {
+		a = a.Add(a, big.NewInt(1))
+	}
 	sa := a.Text(10)
 
 	if scale > 0 {

--- a/types/converter_test.go
+++ b/types/converter_test.go
@@ -78,4 +78,76 @@ func TestDECIMAL(t *testing.T) {
 	if sa10 != "0.0001" {
 		t.Error("DECIMAL_INT_ToString error: ", a10, sa10)
 	}
+
+	a11, _ := StrToParquetType("-100000", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa11 := DECIMAL_BYTE_ARRAY_ToString([]byte(a11.(string)), 8, 4)
+	if sa11 != "-100000.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a11, sa11)
+	}
+
+	a12, _ := StrToParquetType("100000", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa12 := DECIMAL_BYTE_ARRAY_ToString([]byte(a12.(string)), 8, 4)
+	if sa12 != "100000.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a12, sa12)
+	}
+
+	a13, _ := StrToParquetType("-100", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa13 := DECIMAL_BYTE_ARRAY_ToString([]byte(a13.(string)), 8, 4)
+	if sa13 != "-100.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a13, sa13)
+	}
+
+	a14, _ := StrToParquetType("100", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa14 := DECIMAL_BYTE_ARRAY_ToString([]byte(a14.(string)), 8, 4)
+	if sa14 != "100.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a14, sa14)
+	}
+
+	a15, _ := StrToParquetType("-431", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa15 := DECIMAL_BYTE_ARRAY_ToString([]byte(a15.(string)), 8, 4)
+	if sa15 != "-431.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a15, sa15)
+	}
+
+	a16, _ := StrToParquetType("431", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa16 := DECIMAL_BYTE_ARRAY_ToString([]byte(a16.(string)), 8, 4)
+	if sa16 != "431.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a16, sa16)
+	}
+
+	a17, _ := StrToParquetType("-432", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa17 := DECIMAL_BYTE_ARRAY_ToString([]byte(a17.(string)), 8, 4)
+	if sa17 != "-432.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a17, sa17)
+	}
+
+	a18, _ := StrToParquetType("432", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa18 := DECIMAL_BYTE_ARRAY_ToString([]byte(a18.(string)), 8, 4)
+	if sa18 != "432.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a18, sa18)
+	}
+
+	a19, _ := StrToParquetType("-433", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa19 := DECIMAL_BYTE_ARRAY_ToString([]byte(a19.(string)), 8, 4)
+	if sa19 != "-433.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a19, sa19)
+	}
+
+	a20, _ := StrToParquetType("433", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa20 := DECIMAL_BYTE_ARRAY_ToString([]byte(a20.(string)), 8, 4)
+	if sa20 != "433.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a20, sa20)
+	}
+
+	a21, _ := StrToParquetType("-65535", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa21 := DECIMAL_BYTE_ARRAY_ToString([]byte(a21.(string)), 8, 4)
+	if sa21 != "-65535.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a21, sa21)
+	}
+
+	a22, _ := StrToParquetType("65535", parquet.TypePtr(parquet.Type_BYTE_ARRAY), parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL), 8, 4)
+	sa22 := DECIMAL_BYTE_ARRAY_ToString([]byte(a22.(string)), 8, 4)
+	if sa22 != "65535.0000" {
+		t.Error("DECIMAL_BYTE_ARRAY_ToString error: ", a22, sa22)
+	}
 }


### PR DESCRIPTION
This fixes a bug in DECIMAL_BYTE_ARRAY_ToString.

If the number to be converted is a negative number divisible by 16, the conversion would swallow adding +1 (needed for negative numbers) if the original number is divisible by 16.

Example:
The byte code “\x88\xcal\x00” should be turned into -200000.0000, but in the old code we are turning it into -199999.9744.
The issue was introduced here when support for negative numbers was added: https://github.com/xitongsys/parquet-go/pull/433

This converted “\x88\xcal\x00” to 77359300 in Hexdecimal which is 1999999744 in Decimal. But it should be 77359400 in Hexadecimal which would be 2000000000.

Because it is a negative number, we need to add +1 in the end. Let’s say the number is 1ff in Hexadecimal (which is 15 * 16^0 + 15 * 16^1 + 1 * 16^2 = 511). We are then adding +1 to it which should make it 200 in Hexadecimal (which is 0 * 16^0 + 0 * 16^1 + 2 * 16^2 = 512) but we were making it 100 in Hexadecimal (which would be 256 in Decimal).
So essentially, when we add +1 to the last two (Hexadecimal) digits, we are forgetting to update the digits just before it.
This is why this bug only happens for numbers divisible by 16. Because 1fe would just be counted up to 1ff. And even 1ef would be properly counted up to 1f0.