### PR TITLE
Provides Error Handling for potential failure in `writer.NewParquetWriter`

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -80,6 +80,9 @@ func NewParquetWriter(pFile source.ParquetFile, obj interface{}, np int64) (*Par
 	createdBy := "parquet-go version latest"
 	res.Footer.CreatedBy = &createdBy
 	_, err = res.PFile.Write([]byte("PAR1"))
+	if err != nil {
+		return nil, err
+	}
 	res.MarshalFunc = marshal.Marshal
 	res.stopped = true
 


### PR DESCRIPTION
This PR addresses #528.

In the previous implementation, the `err` variable used to capture the result of the first write to the provided `source.ParquetFile` would be overwritten if the provided `obj` was not a `[]*parquet.SchemaElement` before the `err` value is returned at the end of the function. This PR adds an error check after that write is attempted; if the write fails, then the error is returned immediately.

I've also added a unit test demonstrating the behavior and the fix. As part of creating the unit test, I moved the `test` struct type definition out of `TestDoubleWriteStop` so that it could be reused for this test case.