### PR TITLE
fix for handling schema of parquet file which was read

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -92,6 +92,9 @@ func NewParquetWriter(pFile source.ParquetFile, obj interface{}, np int64) (*Par
 			res.stopped = err != nil
 			return res, err
 
+		} else if sa, ok := obj.(*schema.SchemaHandler); ok {
+			res.SchemaHandler = schema.NewSchemaHandlerFromSchemaHandler(sa)
+
 		} else if sa, ok := obj.([]*parquet.SchemaElement); ok {
 			res.SchemaHandler = schema.NewSchemaHandlerFromSchemaList(sa)
 


### PR DESCRIPTION
I needed compress parquet file. So in my case I did not have predefined schema.

When I read the parquet Schema and passed it to `NewParquetWriter` method `NewSchemaHandlerFromSchemaList` set `InName` and `ExName` of columns the same. 

So then I needed to write into new parquet file with compress codec and called method `RenameSchema` it didn't do anything, because `InName` and `ExName` are the same.