### PR TITLE
fix null_count for all-null fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGES=`go list ./... | grep -v example`
 
 test:
-	go test -v -cover ${PACKAGES}
+	go test --count 1 -v -cover ${PACKAGES}
 
 format:
 	go fmt github.com/xitongsys/parquet-go/...

--- a/layout/page.go
+++ b/layout/page.go
@@ -76,7 +76,7 @@ func TableToDataPages(table *Table, pageSize int32, compressType parquet.Compres
 	pT, cT, logT, omitStats := table.Schema.Type, table.Schema.ConvertedType, table.Schema.LogicalType, table.Info.OmitStats
 
 	for i < totalLn {
-		j := i + 1
+		j := i
 		var size int32 = 0
 		var numValues int32 = 0
 


### PR DESCRIPTION
This is to address https://github.com/xitongsys/parquet-go/issues/523.

Also change Makefile to disable test cache.