### PR TITLE
Replace snappy package

### DIFF
--- a/compress/snappy.go
+++ b/compress/snappy.go
@@ -4,7 +4,7 @@
 package compress
 
 import (
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/snappy"
 	"github.com/xitongsys/parquet-go/parquet"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/apache/thrift v0.16.0
 	github.com/aws/aws-sdk-go v1.30.19
 	github.com/goccy/go-reflect v1.2.0
-	github.com/golang/snappy v0.0.4
-	github.com/klauspost/compress v1.15.9
+	github.com/klauspost/compress v1.16.7
 	github.com/pierrec/lz4/v4 v4.1.15
 	github.com/stretchr/testify v1.8.0
 	github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
This will replace the snappy package with a version offering better compression.

Here is a [block compression comparison](https://github.com/klauspost/compress/tree/master/s2#blocks).

This will use the "better" option, which compresses significantly better than the default settings, but at a slightly higher CPU cost. 71.89% -> 75.06%  reduction (11% output size reduction). Speed 725.59 -> 578.49 MB/s (20% CPU increase).

The "balanced" option seems to match the policy of the other compression algorithms. Either way, I think the compression increase will be more noticeable than the CPU usage.