### PR TITLE
close parquetfile after done writing

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -220,6 +220,9 @@ func (pw *ParquetWriter) WriteStop() error {
 	if _, err = pw.PFile.Write([]byte("PAR1")); err != nil {
 		return err
 	}
+	if err = pw.PFile.Close(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Using, for example, the S3 parquet-go-source, nothing will get written into S3 because the ParquetFile in the writer is never closed.  Adding this line allows it to work.

# Testing done
- manual testing
- `make test`