### PR TITLE
add LZ4_RAW support

### DIFF
--- a/compress/lz4_raw.go
+++ b/compress/lz4_raw.go
@@ -1,0 +1,28 @@
+//go:build !no_lz4_raw
+// +build !no_lz4_raw
+
+package compress
+
+import (
+	"github.com/pierrec/lz4/v4"
+	"github.com/xitongsys/parquet-go/parquet"
+)
+
+func init() {
+	lz4hc := lz4.CompressorHC{
+		Level: lz4.CompressionLevel(9),
+	}
+	compressors[parquet.CompressionCodec_LZ4_RAW] = &Compressor{
+		Compress: func(buf []byte) []byte {
+			res := make([]byte, lz4.CompressBlockBound(len(buf)))
+			count, _ := lz4hc.CompressBlock(buf, res)
+			return res[:count]
+		},
+		Uncompress: func(buf []byte) (i []byte, err error) {
+			res := make([]byte, 255*len(buf))
+			count, err := lz4.UncompressBlock(buf, res)
+			res = res[:count]
+			return res[:count], err
+		},
+	}
+}

--- a/compress/lz4_raw_test.go
+++ b/compress/lz4_raw_test.go
@@ -1,0 +1,31 @@
+package compress
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/xitongsys/parquet-go/parquet"
+)
+
+func TestLz4RawCompress(t *testing.T) {
+	lz4RawCompressor := compressors[parquet.CompressionCodec_LZ4_RAW]
+	input := []byte("Peter Parker")
+	compressed := []byte{
+		0xc0, 0x50, 0x65, 0x74, 0x65, 0x72, 0x20, 0x50, 0x61, 0x72, 0x6b, 0x65, 0x72,
+	}
+
+	// compression
+	output := lz4RawCompressor.Compress(input)
+	if !bytes.Equal(compressed, output) {
+		t.Fatalf("expected output %s but was %s", string(compressed), string(output))
+	}
+
+	// uncompression
+	output, err := lz4RawCompressor.Uncompress(compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(input, output) {
+		t.Fatalf("expected output %s but was %s", string(input), string(output))
+	}
+}


### PR DESCRIPTION
This is to address https://github.com/xitongsys/parquet-go/issues/585 by adding LZ4_RAW support, I'm not an expert on compression but I got the magic number `255` in uncompress from https://stackoverflow.com/questions/25740471/lz4-library-decompressed-data-upper-bound-size-estimation.

Ideally if parquet file is using a compression method that is not supported by parquet-go, better give out an error instead of failing quietly.