### PR TITLE
Fix data race on errs slice

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -288,7 +288,7 @@ func (pw *ParquetWriter) flushObjs() error {
 		wg.Add(1)
 		go func(b, e int, index int64) {
 			defer func() {
-				wg.Done()
+				defer wg.Done()
 				if r := recover(); r != nil {
 					switch x := r.(type) {
 					case string:


### PR DESCRIPTION
### Problem

The following scenario is possible and it is leads to data race:

1. In `recover()` branch [wait group is released](https://github.com/xitongsys/parquet-go/blob/693d3323dee08f6a710c9012d40f3f709ee65cd1/writer/writer.go#L291)
2. Then [it is possible to read](https://github.com/xitongsys/parquet-go/blob/693d3323dee08f6a710c9012d40f3f709ee65cd1/writer/writer.go#L339-L341) `errs`
3. But at the same time other goroutine [still can write](https://github.com/xitongsys/parquet-go/blob/693d3323dee08f6a710c9012d40f3f709ee65cd1/writer/writer.go#L295) to `errs`

Thus Race Detector catches concurrent read-write.

### Proposed solution

Call `wg.Done()` by `defer`.  Then the algorithm will look as follows:

1. Write to `errs`
2. `wg.Done()`
3. Read `errs`

In this solution reads go strictly after writes.


